### PR TITLE
FIX: Avoid invalid memory access (possible crash) due to modification of a map that is being iterated over

### DIFF
--- a/src/main/actions/krecentfilesactionext.cpp
+++ b/src/main/actions/krecentfilesactionext.cpp
@@ -142,8 +142,8 @@ void KRecentFilesActionExt::removeUrl(const KUrl & url)
 
 void KRecentFilesActionExt::clearUrls()
 {
-	for(QMap < KUrl, QAction * >::ConstIterator it = m_actions.begin(), end = m_actions.end(); it != end; ++it)
-		removeAction(it.value())->deleteLater();
+	while(!m_actions.empty())
+		removeAction(m_actions.begin().value())->deleteLater();
 
 	removeAction(m_clearHistoryAction);
 	removeAction(m_separatorAction);


### PR DESCRIPTION
While I was debugging an unrelated crash in Ubuntu 13.10 (which is probably not subtitlecomposer's fault, but a bug in Qt), I came across this invalid memory access (invalidating a map iterator by deleting the corresponding map entry and then executing the ++ operator on the invalid iterator), which also has the potential for a crash - although it didn't lead to a segfault in my case.
