### PR TITLE
Fix Settings Dialog: The tabs "Error Check" and "Spell Check" weren't connected to the actual settings.

### DIFF
--- a/src/main/application.cpp
+++ b/src/main/application.cpp
@@ -32,11 +32,7 @@
 #include "actions/kcodecactionext.h"
 #include "actions/krecentfilesactionext.h"
 
-#include "configs/generalconfigwidget.h"
-#include "configs/errorsconfigwidget.h"
-#include <sonnet/configwidget.h>
-//#include "configs/spellingconfigwidget.h"
-#include "configs/playerconfigwidget.h"
+#include "configs/configdialog.h"
 
 #include "dialogs/opensubtitledialog.h"
 #include "dialogs/savesubtitledialog.h"
@@ -127,7 +123,6 @@ Application::Application(int &argc, char **argv) :
 	m_lastFoundLine(0),
 	m_mainWindow(0),
 //  m_audiolevels( 0 ), // FIXME audio levels
-	m_configDialog(0),
 	m_lastSubtitleUrl(QDir::homePath()),
 	m_lastVideoUrl(QDir::homePath()),
 	m_linkCurrentLineToPosition(false)
@@ -426,38 +421,7 @@ Application::buildLevelsFilesFilter()
 void
 Application::showPreferences()
 {
-	if(!m_configDialog) {
-		m_configDialog = new KConfigDialog(m_mainWindow, "scconfig", SCConfig::self());
-
-		KPageWidgetItem *item;
-
-		item = m_configDialog->addPage(new GeneralConfigWidget(NULL), i18nc("@title General settings", "General"));
-		item->setHeader(i18n("General Settings"));
-		item->setIcon(QIcon::fromTheme("preferences-other"));
-
-		item = m_configDialog->addPage(new ErrorsConfigWidget(NULL), i18nc("@title Error Check Settings", "Error Check"));
-		item->setHeader(i18n("Error Check Settings"));
-		item->setIcon(QIcon::fromTheme("games-endturn"));
-
-		item = m_configDialog->addPage(new Sonnet::ConfigWidget(NULL), i18nc("@title Spelling Settings", "Spelling"));
-		item->setHeader(i18n("Spelling Settings"));
-		item->setIcon(QIcon::fromTheme("tools-check-spelling"));
-
-		item = m_configDialog->addPage(new PlayerConfigWidget(NULL), i18nc("@title Player Settings", "Player"));
-		item->setHeader(i18n("Player Settings"));
-		item->setIcon(QIcon::fromTheme("mediaplayer-logo"));
-
-		QStringList backendNames(Player::instance()->backendNames());
-		for(QStringList::ConstIterator it = backendNames.begin(); it != backendNames.end(); it++) {
-			QWidget *configWidget = Player::instance()->backend(*it)->newConfigWidget(0);
-			if(configWidget) {
-				item = m_configDialog->addPage(configWidget, *it);
-				item->setHeader(i18nc("@title Player backend settings", "%1 Backend Settings", *it));
-				item->setIcon(QIcon::fromTheme((*it).toLower() + "-logo"));
-			}
-		}
-	}
-	m_configDialog->show();
+	(new ConfigDialog(m_mainWindow, "scconfig", SCConfig::self()))->show();
 }
 
 void

--- a/src/main/application.h
+++ b/src/main/application.h
@@ -35,10 +35,10 @@
 #include <QKeySequence>
 
 #include <QApplication>
-#include <KConfigDialog>
 #include <QAction>
 #include <QUrl>
 #include <kencodingdetector.h>
+#include <sonnet/configwidget.h>
 
 class KComboBox;
 class QAction;
@@ -300,8 +300,6 @@ private:
 	LinesWidget *m_linesWidget;
 	CurrentLineWidget *m_curLineWidget;
 	StatusBar2 *m_statusBar;
-
-	KConfigDialog *m_configDialog;
 
 	QUrl m_lastSubtitleUrl;
 	KRecentFilesActionExt *m_recentSubtitlesAction;

--- a/src/main/configs/CMakeLists.txt
+++ b/src/main/configs/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(main_configs_SRCS
+	${CMAKE_CURRENT_SOURCE_DIR}/configdialog.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/errorsconfigwidget.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/errorsconfigwidget.ui
 	${CMAKE_CURRENT_SOURCE_DIR}/generalconfigwidget.cpp

--- a/src/main/configs/configdialog.cpp
+++ b/src/main/configs/configdialog.cpp
@@ -1,0 +1,99 @@
+/**
+ * Copyright (C) 2007-2009 Sergio Pistone (sergio_pistone@yahoo.com.ar)
+ * Copyright (C) 2015 Mladen Milinkovic <max@smoothware.net>
+ * Copyright (C) 2015 Martin Steghöfer <martin@steghoefer.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "configs/configdialog.h"
+
+#include "configs/generalconfigwidget.h"
+#include "configs/errorsconfigwidget.h"
+#include "configs/playerconfigwidget.h"
+
+#include "../services/player.h"
+#include "../services/playerbackend.h"
+
+#include <KConfigDialog>
+#include <klocalizedstring.h>
+
+#include <sonnet/configwidget.h>
+
+using namespace SubtitleComposer;
+
+ConfigDialog::ConfigDialog(QWidget *parent, const QString &name, KCoreConfigSkeleton *config) :
+	KConfigDialog(parent, name, config),
+	hasWidgetChanged(false)
+{
+	KPageWidgetItem *item;
+
+	// General page
+	item = addPage(new GeneralConfigWidget(NULL), i18nc("@title General settings", "General"));
+	item->setHeader(i18n("General Settings"));
+	item->setIcon(QIcon::fromTheme("preferences-other"));
+
+	// Error Check page
+	item = addPage(new ErrorsConfigWidget(NULL), i18nc("@title Error Check Settings", "Error Check"));
+	item->setHeader(i18n("Error Check Settings"));
+	item->setIcon(QIcon::fromTheme("games-endturn"));
+
+	// Spelling page
+	sonnetConfigWidget = new Sonnet::ConfigWidget(NULL);
+	connect(sonnetConfigWidget, SIGNAL(configChanged()), this, SLOT(widgetChanged()));
+	item = addPage(sonnetConfigWidget, i18nc("@title Spelling Settings", "Spelling"));
+	item->setHeader(i18n("Spelling Settings"));
+	item->setIcon(QIcon::fromTheme("tools-check-spelling"));
+
+	// Player page
+	item = addPage(new PlayerConfigWidget(NULL), i18nc("@title Player Settings", "Player"));
+	item->setHeader(i18n("Player Settings"));
+	item->setIcon(QIcon::fromTheme("mediaplayer-logo"));
+
+	// Backend pages
+	QStringList backendNames(Player::instance()->backendNames());
+	for(QStringList::ConstIterator it = backendNames.begin(); it != backendNames.end(); it++) {
+		QWidget *configWidget = Player::instance()->backend(*it)->newConfigWidget(0);
+		if(configWidget) {
+			item = addPage(configWidget, *it);
+			item->setHeader(i18nc("@title Player backend settings", "%1 Backend Settings", *it));
+			item->setIcon(QIcon::fromTheme((*it).toLower() + "-logo"));
+		}
+	}
+}
+
+void
+ConfigDialog::widgetChanged()
+{
+	hasWidgetChanged = true;
+	updateButtons();
+}
+
+void
+ConfigDialog::updateSettings()
+{
+	sonnetConfigWidget->save();
+	hasWidgetChanged = false;
+	KConfigDialog::updateSettings();
+	settingsChangedSlot();
+}
+
+bool
+ConfigDialog::hasChanged()
+{
+	return hasWidgetChanged || KConfigDialog::hasChanged();
+}
+

--- a/src/main/configs/configdialog.h
+++ b/src/main/configs/configdialog.h
@@ -1,0 +1,52 @@
+#ifndef CONFIGDIALOG_H
+#define CONFIGDIALOG_H
+
+/**
+ * Copyright (C) 2015 Martin Steghöfer <martin@steghoefer.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include <KConfigDialog>
+
+#include <sonnet/configwidget.h>
+
+namespace SubtitleComposer {
+
+class ConfigDialog : public KConfigDialog
+{
+	Q_OBJECT
+
+public:
+	ConfigDialog(QWidget *parent, const QString &name, KCoreConfigSkeleton *config);
+
+public slots:
+	void widgetChanged();
+
+public:
+	virtual void updateSettings();
+
+protected:
+	virtual bool hasChanged();
+
+private:
+	bool hasWidgetChanged;
+	Sonnet::ConfigWidget *sonnetConfigWidget;
+};
+
+}
+
+#endif

--- a/src/main/configs/errorsconfigwidget.ui
+++ b/src/main/configs/errorsconfigwidget.ui
@@ -18,7 +18,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout" columnstretch="1,1">
       <item row="1" column="1">
-       <widget class="QSpinBox" name="kcfg_SeekOffsetOnDoubleClick">
+       <widget class="QSpinBox" name="kcfg_MaxLines">
         <property name="suffix">
          <string notr="true"> lines</string>
         </property>
@@ -31,7 +31,7 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QSpinBox" name="spinBox">
+       <widget class="QSpinBox" name="kcfg_MaxCharacters">
         <property name="suffix">
          <string> characters</string>
         </property>
@@ -110,7 +110,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_3" columnstretch="1,1">
       <item row="0" column="1">
-       <widget class="QSpinBox" name="spinBox_2">
+       <widget class="QSpinBox" name="kcfg_MinDurationPerCharacter">
         <property name="suffix">
          <string> msec/char</string>
         </property>
@@ -134,7 +134,7 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QSpinBox" name="spinBox_3">
+       <widget class="QSpinBox" name="kcfg_MaxDurationPerCharacter">
         <property name="suffix">
          <string> msec/char</string>
         </property>
@@ -153,7 +153,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
       <item row="0" column="0">
-       <widget class="QCheckBox" name="checkBox">
+       <widget class="QCheckBox" name="kcfg_AutoClearFixed">
         <property name="text">
          <string>Automatically clear fixed errors</string>
         </property>
@@ -178,13 +178,13 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>spinBox</tabstop>
-  <tabstop>kcfg_SeekOffsetOnDoubleClick</tabstop>
-  <tabstop>kcfg_LinesQuickShiftAmount</tabstop>
-  <tabstop>kcfg_GrabbedPositionCompensation</tabstop>
-  <tabstop>spinBox_2</tabstop>
-  <tabstop>spinBox_3</tabstop>
-  <tabstop>checkBox</tabstop>
+  <tabstop>kcfg_MaxCharacters</tabstop>
+  <tabstop>kcfg_MaxLines</tabstop>
+  <tabstop>kcfg_MinDuration</tabstop>
+  <tabstop>kcfg_MaxDuration</tabstop>
+  <tabstop>kcfg_MinDurationPerCharacter</tabstop>
+  <tabstop>kcfg_MaxDurationPerCharacter</tabstop>
+  <tabstop>kcfg_AutoClearFixed</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/main/scconfig.kcfg
+++ b/src/main/scconfig.kcfg
@@ -35,11 +35,11 @@
 
 	<group name="Error Check">
 		<entry name="MaxCharacters" type="Int">
-			<label>Maximun number of characters</label>
+			<label>Maximum number of characters</label>
 			<default>80</default>
 		</entry>
 		<entry name="MaxLines" type="Int">
-			<label>Maximun number of lines</label>
+			<label>Maximum number of lines</label>
 			<default>2</default>
 		</entry>
 


### PR DESCRIPTION
The tabs "Error Check" and "Spell Check" in the Settings dialog were useless. The settings shown in "Error Check" weren't the settings that were actually used by the program. And user changes in both tabs were discarded completely.

The changes in this branch fix those problems. See the commit messages for more technical details on the fixes.