### PR TITLE
add missing khtml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set(CMAKE_AUTOUIC ON)
 find_package(Qt5 ${QT_MIN_VERSION} CONFIG REQUIRED Core Widgets Test)
 
 find_package(KF5 REQUIRED
-	Auth Config ConfigWidgets CoreAddons I18n KIO XmlGui
+	Auth Config ConfigWidgets CoreAddons I18n KIO kHtml XmlGui
 	Sonnet Kross Codecs TextWidgets WidgetsAddons)
 
 add_subdirectory(po)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set(CMAKE_AUTOUIC ON)
 find_package(Qt5 ${QT_MIN_VERSION} CONFIG REQUIRED Core Widgets Test)
 
 find_package(KF5 REQUIRED
-	Auth Config ConfigWidgets CoreAddons I18n KIO kHtml XmlGui
+	Auth Config ConfigWidgets CoreAddons I18n KIO KHtml XmlGui
 	Sonnet Kross Codecs TextWidgets WidgetsAddons)
 
 add_subdirectory(po)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -2,7 +2,7 @@ set(common_LIBS
 	KF5::CoreAddons KF5::WidgetsAddons KF5::TextWidgets KF5::Codecs
 	KF5::SonnetCore KF5::SonnetUi
 	KF5::KIOCore KF5::KIOFileWidgets KF5::KIOWidgets KF5::KIONTLM
-	KF5::KrossCore KF5::KrossUi KF5::XmlGui KF5::I18n
+	KF5::KrossCore KF5::KrossUi KF5::XmlGui KF5::I18n KF5::KHtml
 	CACHE INTERNAL EXPORTEDVARIABLE
 )
 


### PR DESCRIPTION
without build in a clean chroot fails with:
In file included from /buildsys/apps/subtitlecomposer/src/subtitlecomposer-1fabfa245763ecdabdf5e4b9cb13e92723eee1f7/src/services/gstreamer/gstreamerplayerbackend.cpp:25:0:
/buildsys/apps/subtitlecomposer/src/subtitlecomposer-1fabfa245763ecdabdf5e4b9cb13e92723eee1f7/src/services/gstreamer/../../main/application.h:40:31: fatal error: kencodingdetector.h: No such file or directory
 #include <kencodingdetector.h>
                               ^
compilation terminated.