### PR TITLE
fixed Arch Linux PKGBUILDs

### DIFF
--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -12,29 +12,30 @@ pkgver=0.5.8
 pkgrel=1
 pkgdesc="A KDE subtitle editor"
 arch=('i686' 'x86_64')
-url="https://github.com/maxrd2/subtitlecomposer"
+url="https://github.com/maxrd2/${pkgname}"
 license=('GPL')
-depends=('kdelibs' 'gettext')
-makedepends=('cmake' 'automoc4' 'git')
-conflicts=('subtitlecomposer-git')
-install='subtitlecomposer.install'
-optdepends=(
-	'mpv: for MPV backend'
-	'mplayer: for MPlayer backend'
-	'mplayer2: for MPlayer backend'
-	'gstreamer: for GStreamer backend'
-	'xine-lib: for Xine backend'
-	)
-source=("https://github.com/maxrd2/subtitlecomposer/archive/v${pkgver}.tar.gz")
+depends=('kcoreaddons' 'sonnet' 'kcodecs' 'kio' 'kross' 'kxmlgui' 'ki18n')
+# Comment/uncomment the following dependencies to disable/enable support for
+# MPV, gstreamer and/or Xine backend.
+# These are not optdepends as they must be present at build time.
+# Also ensure these deps aren't installed if you don't want to link against them
+# because Subtitle Composer will always link against them if available.
+#depends+=('mpv')
+depends+=('gstreamer')
+depends+=('xine-lib')
+makedepends=('extra-cmake-modules')
+install=${pkgname}.install
+optdepends=('mplayer: for MPlayer backend')
+source=("https://github.com/maxrd2/${pkgname}/archive/v${pkgver}.tar.gz")
 md5sums=('09b95b408af45224c88529b09594349f')
 
 build() {
-	cd ${srcdir}/subtitlecomposer-${pkgver}
-	cmake -DCMAKE_INSTALL_PREFIX=/usr
-	make
+  cd ${srcdir}/${pkgname}-${pkgver}
+  cmake -DCMAKE_INSTALL_PREFIX=/usr
+  make
 }
 
 package() {
-	cd ${srcdir}/subtitlecomposer-${pkgver}
-	make DESTDIR=${pkgdir} install
+  cd ${srcdir}/${pkgname}-${pkgver}
+  make DESTDIR=${pkgdir} install
 } 

--- a/pkg/arch/PKGBUILD-git
+++ b/pkg/arch/PKGBUILD-git
@@ -1,4 +1,6 @@
 # Maintainer: Mladen Milinkovic <maxrd2@smoothware.net>
+# Contributor: Mladen Milinkovic <maxrd2@smoothware.net>
+# Contributor: Martchus <martchus@gmx.net>
 
 # You can install/update Subtitle Composer from repository if you add following to /etc/pacman.conf
 # [subtitlecomposer]
@@ -6,40 +8,43 @@
 # SigLevel = PackageRequired
 # Server = http://smoothware.net/$repo/$arch
 
-pkgname=subtitlecomposer-git
-pkgver=0.5.8
+_name=subtitlecomposer
+pkgname=${_name}-git
+pkgver=v0.5.8
 pkgrel=1
-pkgdesc="A KDE subtitle editor - nightly build"
+pkgdesc="A KDE subtitle editor (git version)"
 arch=('i686' 'x86_64')
-url="https://github.com/maxrd2/subtitlecomposer"
+url="https://github.com/maxrd2/${_name}"
 license=('GPL')
-depends=('kdelibs' 'gettext')
-makedepends=('cmake' 'automoc4' 'git')
-conflicts=('subtitlecomposer')
-install='subtitlecomposer.install'
-optdepends=(
-	'mpv: for MPV backend'
-	'mplayer: for MPlayer backend'
-	'mplayer2: for MPlayer backend'
-	'gstreamer: for GStreamer backend'
-	'xine-lib: for Xine backend'
-	)
-source=('git+https://github.com/maxrd2/subtitlecomposer.git')
+depends=('kcoreaddons' 'sonnet' 'kcodecs' 'kio' 'kross' 'kxmlgui' 'ki18n')
+# Comment/uncomment the following dependencies to disable/enable support for
+# MPV, gstreamer and/or Xine backend.
+# These are not optdepends as they must be present at build time.
+# Also ensure these deps aren't installed if you don't want to link against them
+# because Subtitle Composer will always link against them if available.
+#depends+=('mpv')
+depends+=('gstreamer')
+depends+=('xine-lib')
+makedepends=('extra-cmake-modules' 'git')
+conflicts=(${_name})
+install=${_name}.install
+optdepends=('mplayer: for MPlayer backend')
+source=("git+https://github.com/maxrd2/${_name}.git")
 md5sums=('SKIP')
 
 pkgver() {
-	export APP_VER=${pkgver}
-	cd ${srcdir}/subtitlecomposer
-	git describe --always | sed 's|-|.|g' | sed -e 's/^v//g'
+  export APP_VER=${pkgver}
+  cd ${srcdir}/${_name}
+  git describe --always | sed 's|-|.|g'
 }
 
 build() {
-	cd ${srcdir}/subtitlecomposer
-	cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
-	make
+  cd ${srcdir}/${_name}
+  cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
+  make
 }
 
 package() {
-	cd ${srcdir}/subtitlecomposer
-	make DESTDIR=${pkgdir} install
+  cd ${srcdir}/${_name}
+  make DESTDIR=${pkgdir} install
 }


### PR DESCRIPTION
- Some KF5 libs are required now (instead of kdelibs).
- Dependencies for backends must be non-optional because
  these are required at build time.
- extra-cmake-modules seem to be required to build
- gettext shouldn't be listed as it belongs to base/base-devel.
- fixed indent