### PR TITLE
fixed dependencies of PKGBUILD files (again)

### DIFF
--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -14,28 +14,26 @@ pkgdesc="A KDE subtitle editor"
 arch=('i686' 'x86_64')
 url="https://github.com/maxrd2/${pkgname}"
 license=('GPL')
-depends=('kdebase-runtime' 'kross')
+depends=('kcoreaddons' 'sonnet' 'kcodecs' 'kio' 'kross' 'kxmlgui' 'ki18n')
 # Comment/uncomment the following dependencies to disable/enable support for
 # MPV, gstreamer and/or Xine backend.
 # These are not optdepends as they must be present at build time.
 # Also ensure these deps aren't installed if you don't want to link against them
 # because Subtitle Composer will always link against them if available.
-depends+=('mpv')
+#depends+=('mpv')
 depends+=('gstreamer')
 depends+=('xine-lib')
 makedepends=('extra-cmake-modules')
 install=${pkgname}.install
-optdepends=(
-  'mplayer: for MPlayer backend'
-  'ruby: for scripting'
-  'python: for scripting'
-  )
+optdepends=('mplayer: for MPlayer backend'
+            'ruby: for scripting'
+            'python: for scripting')
 source=("https://github.com/maxrd2/${pkgname}/archive/v${pkgver}.tar.gz")
 md5sums=('e2ce6a23b58645401dd3df6f2cd27f1f')
 
 build() {
   cd ${srcdir}/${pkgname}-${pkgver}
-  cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
+  cmake -DCMAKE_INSTALL_PREFIX=/usr
   make
 }
 

--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -14,7 +14,7 @@ pkgdesc="A KDE subtitle editor"
 arch=('i686' 'x86_64')
 url="https://github.com/maxrd2/${pkgname}"
 license=('GPL')
-depends=('kcoreaddons' 'sonnet' 'kcodecs' 'kio' 'kross' 'kxmlgui' 'ki18n')
+depends=('kcoreaddons' 'sonnet' 'kcodecs' 'kross' 'kxmlgui' 'ki18n')
 # Comment/uncomment the following dependencies to disable/enable support for
 # MPV, gstreamer and/or Xine backend.
 # These are not optdepends as they must be present at build time.

--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -33,7 +33,7 @@ md5sums=('e2ce6a23b58645401dd3df6f2cd27f1f')
 
 build() {
   cd ${srcdir}/${pkgname}-${pkgver}
-  cmake -DCMAKE_INSTALL_PREFIX=/usr
+  cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
   make
 }
 

--- a/pkg/arch/PKGBUILD-git
+++ b/pkg/arch/PKGBUILD-git
@@ -1,4 +1,5 @@
 # Maintainer: Mladen Milinkovic <maxrd2@smoothware.net>
+# Contributor: Mladen Milinkovic <maxrd2@smoothware.net>
 # Contributor: Martchus <martchus@gmx.net>
 
 # You can install/update Subtitle Composer from repository if you add following to /etc/pacman.conf
@@ -15,30 +16,28 @@ pkgdesc="A KDE subtitle editor (git version)"
 arch=('i686' 'x86_64')
 url="https://github.com/maxrd2/${_name}"
 license=('GPL')
-depends=('kdebase-runtime' 'kross')
+depends=('kcoreaddons' 'sonnet' 'kcodecs' 'kio' 'kross' 'kxmlgui' 'ki18n')
 # Comment/uncomment the following dependencies to disable/enable support for
 # MPV, gstreamer and/or Xine backend.
 # These are not optdepends as they must be present at build time.
 # Also ensure these deps aren't installed if you don't want to link against them
 # because Subtitle Composer will always link against them if available.
-depends+=('mpv')
+#depends+=('mpv')
 depends+=('gstreamer')
 depends+=('xine-lib')
 makedepends=('extra-cmake-modules' 'git')
 conflicts=(${_name})
 install=${_name}.install
-optdepends=(
-  'mplayer: for MPlayer backend'
-  'ruby: for scripting'
-  'python: for scripting'
-  )
+optdepends=('mplayer: for MPlayer backend'
+            'ruby: for scripting'
+            'python: for scripting')
 source=("git+https://github.com/maxrd2/${_name}.git")
 md5sums=('SKIP')
 
 pkgver() {
   export APP_VER=${pkgver}
   cd ${srcdir}/${_name}
-  git describe --always | sed 's|-|.|g' | sed -e 's/^v//g'
+  git describe --always | sed 's|-|.|g'
 }
 
 build() {

--- a/pkg/arch/PKGBUILD-git
+++ b/pkg/arch/PKGBUILD-git
@@ -16,7 +16,7 @@ pkgdesc="A KDE subtitle editor (git version)"
 arch=('i686' 'x86_64')
 url="https://github.com/maxrd2/${_name}"
 license=('GPL')
-depends=('kcoreaddons' 'sonnet' 'kcodecs' 'kio' 'kross' 'kxmlgui' 'ki18n')
+depends=('kcoreaddons' 'sonnet' 'kcodecs' 'kross' 'kxmlgui' 'ki18n')
 # Comment/uncomment the following dependencies to disable/enable support for
 # MPV, gstreamer and/or Xine backend.
 # These are not optdepends as they must be present at build time.

--- a/pkg/arch/PKGBUILD-git
+++ b/pkg/arch/PKGBUILD-git
@@ -37,7 +37,7 @@ md5sums=('SKIP')
 pkgver() {
   export APP_VER=${pkgver}
   cd ${srcdir}/${_name}
-  git describe --always | sed 's|-|.|g'
+  git describe --always | sed 's|-|.|g' | sed -e 's/^v//g'
 }
 
 build() {


### PR DESCRIPTION
I guess you dropped the KF5 dependencies accidentally when merging the changes.

Anyways, "readelf -d /usr/bin/subtitlecomposer" clearly prints that Subtitle Composer is now linking against KF5 libs, eg.
> Shared library: [libKF5WidgetsAddons.so.5]

But I'm not even able to build without KF5 deps. I suspect you don't build in a clean chroot when building the packages for your repo at smoothware.net so you don't notice the problems.

I also disabled the MPV plugin on purpose. MPV is not so popular as the other backends. The remaining 3 backends should be sufficient for the casual user which might want to avoid installing software which he doesn't use. I guess this assumption is especially true for Arch users.

By the way: I also removed mplayer2 on purpose. As mplayer2 provides mplayer having just mplayer is sufficient. The AUR proposes all providing packages automatically.