### PR TITLE
further code cleanup

### DIFF
--- a/src/common/commondefs.cpp
+++ b/src/common/commondefs.cpp
@@ -23,11 +23,11 @@
 #include <cstdlib>
 #include <climits>
 
-#include <QtCore/QString>
-#include <QtCore/QStringList>
-#include <QtCore/QRegExp>
-#include <QtCore/QDir>
-#include <QtCore/QFileInfo>
+#include <QString>
+#include <QStringList>
+#include <QRegExp>
+#include <QDir>
+#include <QFileInfo>
 
 #include <QDebug>
 #include <QStandardPaths>

--- a/src/common/commondefs.h
+++ b/src/common/commondefs.h
@@ -25,8 +25,8 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QString>
-#include <QtCore/QStringList>
+#include <QString>
+#include <QStringList>
 
 #include <QUrl>
 

--- a/src/common/filesavehelper.h
+++ b/src/common/filesavehelper.h
@@ -25,7 +25,7 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QFile>
+#include <QFile>
 
 #include <QUrl>
 #include <QFileDevice>

--- a/src/common/languagecode.cpp
+++ b/src/common/languagecode.cpp
@@ -20,8 +20,7 @@
 
 #include "languagecode.h"
 
-#include <QtCore/QMap>
-
+#include <QMap>
 #include <QLocale>
 
 #include <KLocalizedString>

--- a/src/common/languagecode.h
+++ b/src/common/languagecode.h
@@ -24,7 +24,7 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QString>
+#include <QString>
 
 class LanguageCode
 {

--- a/src/common/qxtsignalwaiter.cpp
+++ b/src/common/qxtsignalwaiter.cpp
@@ -21,8 +21,8 @@
 
 #include "qxtsignalwaiter.h"
 
-#include <QtCore/QCoreApplication>
-#include <QtCore/QTimerEvent>
+#include <QCoreApplication>
+#include <QTimerEvent>
 
 QxtSignalWaiter::QxtSignalWaiter(const QObject *sender, const char *signal, unsigned count) :
 	QObject(0),

--- a/src/common/qxtsignalwaiter.h
+++ b/src/common/qxtsignalwaiter.h
@@ -26,8 +26,8 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QObject>
-#include <QtCore/QEventLoop>
+#include <QObject>
+#include <QEventLoop>
 
 QT_FORWARD_DECLARE_CLASS(QTimerEvent);
 

--- a/src/core/action.h
+++ b/src/core/action.h
@@ -26,7 +26,7 @@
 
 #include <typeinfo>
 
-#include <QtCore/QString>
+#include <QString>
 
 namespace SubtitleComposer {
 class Action

--- a/src/core/actionmanager.h
+++ b/src/core/actionmanager.h
@@ -26,9 +26,9 @@
 
 #include "action.h"
 
-#include <QtCore/QObject>
-#include <QtCore/QTime>
-#include <QtCore/QLinkedList>
+#include <QObject>
+#include <QTime>
+#include <QLinkedList>
 
 namespace SubtitleComposer {
 class ActionManager : public QObject

--- a/src/core/audiolevels.cpp
+++ b/src/core/audiolevels.cpp
@@ -25,8 +25,8 @@
 #include <vector>
 #include <cmath>                                // FIXME remove when unneeded
 
-#include <QtCore/QFile>
-#include <QtCore/QTextStream>
+#include <QFile>
+#include <QTextStream>
 
 using namespace SubtitleComposer;
 

--- a/src/core/audiolevels.h
+++ b/src/core/audiolevels.h
@@ -26,7 +26,7 @@
 
 #include "time.h"
 
-#include <QtCore/QObject>
+#include <QObject>
 
 #include <QUrl>
 

--- a/src/core/compositeaction.h
+++ b/src/core/compositeaction.h
@@ -26,8 +26,8 @@
 
 #include "action.h"
 
-#include <QtCore/QString>
-#include <QtCore/QLinkedList>
+#include <QString>
+#include <QLinkedList>
 
 namespace SubtitleComposer {
 class CompositeAction : public Action

--- a/src/core/formatdata.h
+++ b/src/core/formatdata.h
@@ -24,8 +24,8 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QString>
-#include <QtCore/QMap>
+#include <QString>
+#include <QMap>
 
 namespace SubtitleComposer {
 class FormatData

--- a/src/core/range.h
+++ b/src/core/range.h
@@ -26,7 +26,7 @@
 
 #include <climits>
 
-#include <QtCore/QList>
+#include <QList>
 
 #include <QDebug>
 

--- a/src/core/rangelist.h
+++ b/src/core/rangelist.h
@@ -26,7 +26,7 @@
 
 #include "range.h"
 
-#include <QtCore/QList>
+#include <QList>
 #include <QStringList>
 
 #include <QDebug>

--- a/src/core/sstring.cpp
+++ b/src/core/sstring.cpp
@@ -19,8 +19,8 @@
 
 #include "sstring.h"
 
-#include <QtCore/QList>
-#include <QtCore/QStringList>
+#include <QList>
+#include <QStringList>
 
 #include <QDebug>
 

--- a/src/core/sstring.h
+++ b/src/core/sstring.h
@@ -26,9 +26,9 @@
 
 #include <string.h>
 
-#include <QtCore/QString>
-#include <QtCore/QRegExp>
-#include <QtCore/QList>
+#include <QString>
+#include <QRegExp>
+#include <QList>
 #include <QColor>
 
 #include <QDebug>

--- a/src/core/subtitle.h
+++ b/src/core/subtitle.h
@@ -32,10 +32,10 @@
 #include "actionmanager.h"
 #include "formatdata.h"
 
-#include <QtCore/QObject>
-#include <QtCore/QString>
-#include <QtCore/QStringList>
-#include <QtCore/QList>
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QList>
 
 namespace SubtitleComposer {
 class CompositeAction;

--- a/src/core/subtitleactions.cpp
+++ b/src/core/subtitleactions.cpp
@@ -23,7 +23,7 @@
 #include "subtitleline.h"
 #include "sstring.h"
 
-#include <QtCore/QObject>
+#include <QObject>
 
 #include <KLocalizedString>
 

--- a/src/core/subtitleactions.h
+++ b/src/core/subtitleactions.h
@@ -28,8 +28,8 @@
 #include "rangelist.h"
 #include "subtitle.h"
 
-#include <QtCore/QString>
-#include <QtCore/QList>
+#include <QString>
+#include <QList>
 
 namespace SubtitleComposer {
 class CompositeAction;

--- a/src/core/subtitleiterator.h
+++ b/src/core/subtitleiterator.h
@@ -29,8 +29,8 @@
 #include "range.h"
 #include "rangelist.h"
 
-#include <QtCore/QObject>
-#include <QtCore/QList>
+#include <QObject>
+#include <QList>
 
 namespace SubtitleComposer {
 class SubtitleIterator : public QObject

--- a/src/core/subtitleline.cpp
+++ b/src/core/subtitleline.cpp
@@ -22,7 +22,7 @@
 #include "subtitlelineactions.h"
 #include "subtitle.h"
 
-#include <QtCore/QRegExp>
+#include <QRegExp>
 
 #include <KLocalizedString>
 

--- a/src/core/subtitleline.h
+++ b/src/core/subtitleline.h
@@ -29,8 +29,8 @@
 #include "time.h"
 #include "formatdata.h"
 
-#include <QtCore/QObject>
-#include <QtCore/QString>
+#include <QObject>
+#include <QString>
 
 namespace SubtitleComposer {
 class Subtitle;

--- a/src/core/subtitlelineactions.h
+++ b/src/core/subtitlelineactions.h
@@ -30,7 +30,7 @@
 #include "subtitleline.h"
 #include "subtitleactions.h"
 
-#include <QtCore/QString>
+#include <QString>
 
 namespace SubtitleComposer {
 class SubtitleLineAction : public Action

--- a/src/core/tests/rangelisttest.h
+++ b/src/core/tests/rangelisttest.h
@@ -24,7 +24,7 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QObject>
+#include <QObject>
 
 class RangeListTest : public QObject
 {

--- a/src/core/tests/rangetest.h
+++ b/src/core/tests/rangetest.h
@@ -24,7 +24,7 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QObject>
+#include <QObject>
 
 class RangeTest : public QObject
 {

--- a/src/core/tests/sstringtest.h
+++ b/src/core/tests/sstringtest.h
@@ -24,7 +24,7 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QObject>
+#include <QObject>
 
 class SStringTest : public QObject
 {

--- a/src/core/tests/timetest.h
+++ b/src/core/tests/timetest.h
@@ -24,7 +24,7 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QObject>
+#include <QObject>
 
 class TimeTest : public QObject
 {

--- a/src/core/time.h
+++ b/src/core/time.h
@@ -24,7 +24,7 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QString>
+#include <QString>
 
 namespace SubtitleComposer {
 class Time

--- a/src/formats/format.h
+++ b/src/formats/format.h
@@ -28,8 +28,8 @@
 #include "../core/subtitle.h"
 #include "../core/subtitleline.h"
 
-#include <QtCore/QString>
-#include <QtCore/QStringList>
+#include <QString>
+#include <QStringList>
 
 namespace SubtitleComposer {
 class Format

--- a/src/formats/formatmanager.cpp
+++ b/src/formats/formatmanager.cpp
@@ -42,10 +42,10 @@
 #include "youtubecaptions/youtubecaptionsinputformat.h"
 #include "youtubecaptions/youtubecaptionsoutputformat.h"
 
-#include <QtCore/QFile>
-#include <QtCore/QFileInfo>
-#include <QtCore/QTextCodec>
-#include <QtCore/QTextStream>
+#include <QFile>
+#include <QFileInfo>
+#include <QTextCodec>
+#include <QTextStream>
 
 #include <KCharsets>
 #include <QUrl>

--- a/src/formats/formatmanager.h
+++ b/src/formats/formatmanager.h
@@ -27,9 +27,9 @@
 #include "inputformat.h"
 #include "outputformat.h"
 
-#include <QtCore/QString>
-#include <QtCore/QStringList>
-#include <QtCore/QMap>
+#include <QString>
+#include <QStringList>
+#include <QMap>
 
 #include <QUrl>
 #include <KEncodingProber>

--- a/src/formats/inputformat.h
+++ b/src/formats/inputformat.h
@@ -30,8 +30,6 @@ namespace SubtitleComposer {
 class InputFormat : public Format
 {
 public:
-	virtual ~InputFormat() {}
-
 	bool readSubtitle(Subtitle &subtitle, bool primary, const QString &data) const
 	{
 		Subtitle newSubtitle;

--- a/src/formats/microdvd/microdvdinputformat.h
+++ b/src/formats/microdvd/microdvdinputformat.h
@@ -26,16 +26,13 @@
 
 #include "../inputformat.h"
 
-#include <QtCore/QRegExp>
-#include <QtCore/QStringBuilder>
+#include <QRegExp>
+#include <QStringBuilder>
 
 namespace SubtitleComposer {
 class MicroDVDInputFormat : public InputFormat
 {
 	friend class FormatManager;
-
-public:
-	virtual ~MicroDVDInputFormat() {}
 
 protected:
 	virtual bool parseSubtitles(Subtitle &subtitle, const QString &data) const

--- a/src/formats/mplayer/mplayerinputformat.h
+++ b/src/formats/mplayer/mplayerinputformat.h
@@ -26,15 +26,12 @@
 
 #include "../inputformat.h"
 
-#include <QtCore/QRegExp>
+#include <QRegExp>
 
 namespace SubtitleComposer {
 class MPlayerInputFormat : public InputFormat
 {
 	friend class FormatManager;
-
-public:
-	virtual ~MPlayerInputFormat() {}
 
 protected:
 	virtual bool parseSubtitles(Subtitle &subtitle, const QString &data) const

--- a/src/formats/mplayer/mplayeroutputformat.h
+++ b/src/formats/mplayer/mplayeroutputformat.h
@@ -32,9 +32,6 @@ class MPlayerOutputFormat : public OutputFormat
 {
 	friend class FormatManager;
 
-public:
-	virtual ~MPlayerOutputFormat() {}
-
 protected:
 	virtual QString dumpSubtitles(const Subtitle &subtitle, bool primary) const
 	{

--- a/src/formats/mplayer2/mplayer2inputformat.h
+++ b/src/formats/mplayer2/mplayer2inputformat.h
@@ -26,15 +26,12 @@
 
 #include "../inputformat.h"
 
-#include <QtCore/QRegExp>
+#include <QRegExp>
 
 namespace SubtitleComposer {
 class MPlayer2InputFormat : public InputFormat
 {
 	friend class FormatManager;
-
-public:
-	virtual ~MPlayer2InputFormat() {}
 
 protected:
 	virtual bool parseSubtitles(Subtitle &subtitle, const QString &data) const

--- a/src/formats/mplayer2/mplayer2outputformat.h
+++ b/src/formats/mplayer2/mplayer2outputformat.h
@@ -32,9 +32,6 @@ class MPlayer2OutputFormat : public OutputFormat
 {
 	friend class FormatManager;
 
-public:
-	virtual ~MPlayer2OutputFormat() {}
-
 protected:
 	virtual QString dumpSubtitles(const Subtitle &subtitle, bool primary) const
 	{

--- a/src/formats/outputformat.h
+++ b/src/formats/outputformat.h
@@ -29,7 +29,6 @@ namespace SubtitleComposer {
 class OutputFormat : public Format
 {
 public:
-	virtual ~OutputFormat() {}
 
 	QString writeSubtitle(const Subtitle &subtitle, bool primary) const
 	{

--- a/src/formats/subrip/subripinputformat.h
+++ b/src/formats/subrip/subripinputformat.h
@@ -26,15 +26,12 @@
 
 #include "../inputformat.h"
 
-#include <QtCore/QRegExp>
+#include <QRegExp>
 
 namespace SubtitleComposer {
 class SubRipInputFormat : public InputFormat
 {
 	friend class FormatManager;
-
-public:
-	virtual ~SubRipInputFormat() {}
 
 protected:
 	virtual bool parseSubtitles(Subtitle &subtitle, const QString &data) const

--- a/src/formats/subrip/subripoutputformat.h
+++ b/src/formats/subrip/subripoutputformat.h
@@ -32,9 +32,6 @@ class SubRipOutputFormat : public OutputFormat
 {
 	friend class FormatManager;
 
-public:
-	virtual ~SubRipOutputFormat() {}
-
 protected:
 	virtual QString dumpSubtitles(const Subtitle &subtitle, bool primary) const
 	{

--- a/src/formats/substationalpha/substationalphainputformat.h
+++ b/src/formats/substationalpha/substationalphainputformat.h
@@ -34,9 +34,6 @@ class SubStationAlphaInputFormat : public InputFormat
 	friend class FormatManager;
 	friend class AdvancedSubStationAlphaInputFormat;
 
-public:
-	virtual ~SubStationAlphaInputFormat() {}
-
 protected:
 	SString toSString(QString string) const
 	{

--- a/src/formats/substationalpha/substationalphaoutputformat.h
+++ b/src/formats/substationalpha/substationalphaoutputformat.h
@@ -34,8 +34,6 @@ class SubStationAlphaOutputFormat : public OutputFormat
 	friend class FormatManager;
 
 public:
-	virtual ~SubStationAlphaOutputFormat() {}
-
 	QString fromSString(const SString &text) const
 	{
 

--- a/src/formats/subviewer1/subviewer1inputformat.h
+++ b/src/formats/subviewer1/subviewer1inputformat.h
@@ -26,15 +26,12 @@
 
 #include "../inputformat.h"
 
-#include <QtCore/QRegExp>
+#include <QRegExp>
 
 namespace SubtitleComposer {
 class SubViewer1InputFormat : public InputFormat
 {
 	friend class FormatManager;
-
-public:
-	virtual ~SubViewer1InputFormat() {}
 
 protected:
 	virtual bool parseSubtitles(Subtitle &subtitle, const QString &data) const

--- a/src/formats/subviewer1/subviewer1outputformat.h
+++ b/src/formats/subviewer1/subviewer1outputformat.h
@@ -32,9 +32,6 @@ class SubViewer1OutputFormat : public OutputFormat
 {
 	friend class FormatManager;
 
-public:
-	virtual ~SubViewer1OutputFormat() {}
-
 protected:
 	virtual QString dumpSubtitles(const Subtitle &subtitle, bool primary) const
 	{

--- a/src/formats/subviewer2/subviewer2inputformat.h
+++ b/src/formats/subviewer2/subviewer2inputformat.h
@@ -26,15 +26,12 @@
 
 #include "../inputformat.h"
 
-#include <QtCore/QRegExp>
+#include <QRegExp>
 
 namespace SubtitleComposer {
 class SubViewer2InputFormat : public InputFormat
 {
 	friend class FormatManager;
-
-public:
-	virtual ~SubViewer2InputFormat() {}
 
 protected:
 	virtual bool parseSubtitles(Subtitle &subtitle, const QString &data) const

--- a/src/formats/subviewer2/subviewer2outputformat.h
+++ b/src/formats/subviewer2/subviewer2outputformat.h
@@ -32,9 +32,6 @@ class SubViewer2OutputFormat : public OutputFormat
 {
 	friend class FormatManager;
 
-public:
-	virtual ~SubViewer2OutputFormat() {}
-
 protected:
 	virtual QString dumpSubtitles(const Subtitle &subtitle, bool primary) const
 	{

--- a/src/formats/tmplayer/tmplayerinputformat.h
+++ b/src/formats/tmplayer/tmplayerinputformat.h
@@ -26,7 +26,7 @@
 
 #include "../inputformat.h"
 
-#include <QtCore/QRegExp>
+#include <QRegExp>
 
 namespace SubtitleComposer {
 // FIXME TMPlayer Multiline variant
@@ -34,9 +34,6 @@ namespace SubtitleComposer {
 class TMPlayerInputFormat : public InputFormat
 {
 	friend class FormatManager;
-
-public:
-	virtual ~TMPlayerInputFormat() {}
 
 protected:
 	virtual bool parseSubtitles(Subtitle &subtitle, const QString &data) const

--- a/src/formats/tmplayer/tmplayeroutputformat.h
+++ b/src/formats/tmplayer/tmplayeroutputformat.h
@@ -32,9 +32,6 @@ class TMPlayerOutputFormat : public OutputFormat
 {
 	friend class FormatManager;
 
-public:
-	virtual ~TMPlayerOutputFormat() {}
-
 protected:
 	virtual QString dumpSubtitles(const Subtitle &subtitle, bool primary) const
 	{

--- a/src/formats/youtubecaptions/youtubecaptionsinputformat.h
+++ b/src/formats/youtubecaptions/youtubecaptionsinputformat.h
@@ -26,15 +26,12 @@
 
 #include "../inputformat.h"
 
-#include <QtCore/QRegExp>
+#include <QRegExp>
 
 namespace SubtitleComposer {
 class YouTubeCaptionsInputFormat : public InputFormat
 {
 	friend class FormatManager;
-
-public:
-	virtual ~YouTubeCaptionsInputFormat() {}
 
 protected:
 	virtual bool parseSubtitles(Subtitle &subtitle, const QString &data) const

--- a/src/formats/youtubecaptions/youtubecaptionsoutputformat.h
+++ b/src/formats/youtubecaptions/youtubecaptionsoutputformat.h
@@ -32,9 +32,6 @@ class YouTubeCaptionsOutputFormat : public OutputFormat
 {
 	friend class FormatManager;
 
-public:
-	virtual ~YouTubeCaptionsOutputFormat() {}
-
 protected:
 	virtual QString dumpSubtitles(const Subtitle &subtitle, bool primary) const
 	{
@@ -68,8 +65,8 @@ protected:
 	}
 
 	YouTubeCaptionsOutputFormat() :
-		OutputFormat("YouTube Captions", QStringList("sbv")),
-		m_dialogueBuilder("%1%2%3%4%5%6%7\n\n")
+		OutputFormat(QStringLiteral("YouTube Captions"), QStringList(QStringLiteral("sbv"))),
+		m_dialogueBuilder(QStringLiteral("%1%2%3%4%5%6%7\n\n"))
 	{}
 
 	const QString m_dialogueBuilder;

--- a/src/main/actions/kcodecactionext.cpp
+++ b/src/main/actions/kcodecactionext.cpp
@@ -20,8 +20,8 @@
 
 #include "kcodecactionext.h"
 
-#include <QtCore/QVariant>
-#include <QtCore/QTextCodec>
+#include <QVariant>
+#include <QTextCodec>
 #include <QMenu>
 #include <QDebug>
 

--- a/src/main/actions/krecentfilesactionext.cpp
+++ b/src/main/actions/krecentfilesactionext.cpp
@@ -22,7 +22,7 @@
 
 #include "common/commondefs.h"
 
-#include <QtCore/QFile>
+#include <QFile>
 #include <QDebug>
 #include <QStandardPaths>
 

--- a/src/main/actions/useraction.h
+++ b/src/main/actions/useraction.h
@@ -24,7 +24,7 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QList>
+#include <QList>
 
 #include <QAction>
 

--- a/src/main/application.cpp
+++ b/src/main/application.cpp
@@ -75,11 +75,11 @@
 #include "../services/decoderbackend.h"
 #include "../profiler.h"
 
-#include <QtCore/QDir>
-#include <QtCore/QFileInfo>
-#include <QtCore/QTextCodec>
-#include <QtCore/QProcess>
-#include <QtCore/QStringBuilder>
+#include <QDir>
+#include <QFileInfo>
+#include <QTextCodec>
+#include <QProcess>
+#include <QStringBuilder>
 #include <QGridLayout>
 #include <QMenu>
 
@@ -222,8 +222,7 @@ Application::~Application()
 
 	// delete m_mainWindow; the window is destroyed when it's closed
 
-	if(m_subtitle)
-		delete m_subtitle;
+	delete m_subtitle;
 //  delete m_audiolevels; // FIXME audio levels
 }
 

--- a/src/main/application.h
+++ b/src/main/application.h
@@ -30,8 +30,8 @@
 #include "../formats/format.h"
 #include "scconfig.h"
 
-#include <QtCore/QMap>
-#include <QtCore/QString>
+#include <QMap>
+#include <QString>
 #include <QKeySequence>
 
 #include <QApplication>

--- a/src/main/audiolevelswidget.cpp
+++ b/src/main/audiolevelswidget.cpp
@@ -21,7 +21,7 @@
 #include "../core/subtitleline.h"
 #include "../services/player.h"
 
-#include <QtCore/QRect>
+#include <QRect>
 #include <QPainter>
 #include <QPaintEvent>
 #include <QRegion>

--- a/src/main/currentlinewidget.cpp
+++ b/src/main/currentlinewidget.cpp
@@ -24,7 +24,7 @@
 #include "../widgets/timeedit.h"
 #include "../widgets/simplerichtextedit.h"
 
-#include <QtCore/QTimer>
+#include <QTimer>
 #include <QLabel>
 #include <QToolButton>
 #include <QGroupBox>

--- a/src/main/dialogs/selectablesubtitledialog.cpp
+++ b/src/main/dialogs/selectablesubtitledialog.cpp
@@ -22,7 +22,7 @@
 #include "opensubtitledialog.h"
 #include "../application.h"
 
-#include <QtCore/QTextCodec>
+#include <QTextCodec>
 #include <QLabel>
 #include <QGroupBox>
 #include <QGridLayout>

--- a/src/main/dialogs/translatedialog.cpp
+++ b/src/main/dialogs/translatedialog.cpp
@@ -20,7 +20,7 @@
 
 #include "translatedialog.h"
 
-#include <QtCore/QFile>
+#include <QFile>
 #include <QLabel>
 #include <QComboBox>
 #include <QGroupBox>

--- a/src/main/errorswidget.cpp
+++ b/src/main/errorswidget.cpp
@@ -27,7 +27,7 @@
 
 #include <climits>
 
-#include <QtCore/QTimer>
+#include <QTimer>
 #include <QKeyEvent>
 #include <QMouseEvent>
 #include <QContextMenuEvent>

--- a/src/main/errorswidget.h
+++ b/src/main/errorswidget.h
@@ -28,8 +28,8 @@
 #include "../core/subtitle.h"
 #include "../widgets/treeview.h"
 
-#include <QtCore/QList>
-#include <QtCore/QAbstractItemModel>
+#include <QList>
+#include <QAbstractItemModel>
 
 QT_FORWARD_DECLARE_CLASS(QTimer)
 

--- a/src/main/lineswidget.cpp
+++ b/src/main/lineswidget.cpp
@@ -23,9 +23,9 @@
 #include "dialogs/actionwithtargetdialog.h"
 #include "profiler.h"
 
-#include <QtCore/QVariant>
-#include <QtCore/QTimer>
-#include <QtCore/QEvent>
+#include <QVariant>
+#include <QTimer>
+#include <QEvent>
 #include <QScrollBar>
 #include <QDropEvent>
 #include <QMimeData>

--- a/src/main/lineswidget.h
+++ b/src/main/lineswidget.h
@@ -29,7 +29,7 @@
 #include "../core/subtitleline.h"
 #include "../widgets/treeview.h"
 
-#include <QtCore/QAbstractItemModel>
+#include <QAbstractItemModel>
 #include <QStyledItemDelegate>
 #include <QStyleOptionViewItemV4>
 #include <QPen>

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -29,8 +29,8 @@
 #include <KAboutData>
 #include <KLocalizedString>
 
-#include <QtCore/QFile>
-#include <QtCore/QDir>
+#include <QFile>
+#include <QDir>
 #include <QCommandLineParser>
 #include <QCommandLineOption>
 

--- a/src/main/playerwidget.cpp
+++ b/src/main/playerwidget.cpp
@@ -30,7 +30,7 @@
 #include "../widgets/pointingslider.h"
 #include "../widgets/timeedit.h"
 
-#include <QtCore/QEvent>
+#include <QEvent>
 #include <QDropEvent>
 #include <QMimeData>
 #include <QKeyEvent>

--- a/src/main/playerwidget.h
+++ b/src/main/playerwidget.h
@@ -29,7 +29,7 @@
 #include "../core/subtitle.h"
 #include "../core/subtitleline.h"
 
-#include <QtCore/QPoint>
+#include <QPoint>
 #include <QWidget>
 
 QT_FORWARD_DECLARE_CLASS(QGridLayout)

--- a/src/main/scripting/scripting_list.h
+++ b/src/main/scripting/scripting_list.h
@@ -24,8 +24,8 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QObject>
-#include <QtCore/QList>
+#include <QObject>
+#include <QList>
 
 namespace SubtitleComposer {
 namespace Scripting {

--- a/src/main/scripting/scripting_range.h
+++ b/src/main/scripting/scripting_range.h
@@ -26,7 +26,7 @@
 
 #include "../../core/range.h"
 
-#include <QtCore/QObject>
+#include <QObject>
 
 namespace SubtitleComposer {
 namespace Scripting {

--- a/src/main/scripting/scripting_rangelist.h
+++ b/src/main/scripting/scripting_rangelist.h
@@ -26,7 +26,7 @@
 
 #include "../../core/rangelist.h"
 
-#include <QtCore/QObject>
+#include <QObject>
 
 namespace SubtitleComposer {
 namespace Scripting {

--- a/src/main/scripting/scripting_rangesmodule.h
+++ b/src/main/scripting/scripting_rangesmodule.h
@@ -24,7 +24,7 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QObject>
+#include <QObject>
 
 namespace SubtitleComposer {
 namespace Scripting {

--- a/src/main/scripting/scripting_sstring.cpp
+++ b/src/main/scripting/scripting_sstring.cpp
@@ -19,7 +19,7 @@
 
 #include "scripting_sstring.h"
 
-#include <QtCore/QRegExp>
+#include <QRegExp>
 
 using namespace SubtitleComposer;
 

--- a/src/main/scripting/scripting_sstring.h
+++ b/src/main/scripting/scripting_sstring.h
@@ -27,8 +27,8 @@
 #include "../../core/sstring.h"
 #include "scripting_list.h"
 
-#include <QtCore/QObject>
-#include <QtCore/QString>
+#include <QObject>
+#include <QString>
 
 namespace SubtitleComposer {
 namespace Scripting {

--- a/src/main/scripting/scripting_stringsmodule.cpp
+++ b/src/main/scripting/scripting_stringsmodule.cpp
@@ -20,7 +20,7 @@
 #include "scripting_stringsmodule.h"
 #include "scripting_sstring.h"
 
-#include <QtCore/QRegExp>
+#include <QRegExp>
 
 using namespace SubtitleComposer;
 

--- a/src/main/scripting/scripting_stringsmodule.h
+++ b/src/main/scripting/scripting_stringsmodule.h
@@ -27,8 +27,8 @@
 #include "../../core/sstring.h"
 #include "scripting_list.h"
 
-#include <QtCore/QObject>
-#include <QtCore/QString>
+#include <QObject>
+#include <QString>
 
 namespace SubtitleComposer {
 namespace Scripting {

--- a/src/main/scripting/scripting_subtitle.h
+++ b/src/main/scripting/scripting_subtitle.h
@@ -28,7 +28,7 @@
 #include "../../core/subtitle.h"
 #include "../../core/rangelist.h"
 
-#include <QtCore/QObject>
+#include <QObject>
 
 namespace SubtitleComposer {
 class Subtitle;

--- a/src/main/scripting/scripting_subtitleline.h
+++ b/src/main/scripting/scripting_subtitleline.h
@@ -26,8 +26,8 @@
 
 #include "../../core/subtitleline.h"
 
-#include <QtCore/QObject>
-#include <QtCore/QString>
+#include <QObject>
+#include <QString>
 
 namespace SubtitleComposer {
 namespace Scripting {

--- a/src/main/scripting/scripting_subtitlelinemodule.h
+++ b/src/main/scripting/scripting_subtitlelinemodule.h
@@ -26,7 +26,7 @@
 
 #include "../../core/subtitleline.h"
 
-#include <QtCore/QObject>
+#include <QObject>
 
 namespace SubtitleComposer {
 namespace Scripting {

--- a/src/main/scripting/scripting_subtitlemodule.h
+++ b/src/main/scripting/scripting_subtitlemodule.h
@@ -24,7 +24,7 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QObject>
+#include <QObject>
 
 #include "../../core/subtitle.h"
 

--- a/src/main/scripting/scriptsmanager.h
+++ b/src/main/scripting/scriptsmanager.h
@@ -25,8 +25,8 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QObject>
-#include <QtCore/QMap>
+#include <QObject>
+#include <QMap>
 #include <QUrl>
 
 #include "ui_scriptsmanager.h"

--- a/src/main/utils/errorfinder.h
+++ b/src/main/utils/errorfinder.h
@@ -26,7 +26,7 @@
 
 #include "../../core/subtitle.h"
 
-#include <QtCore/QObject>
+#include <QObject>
 
 namespace SubtitleComposer {
 class FindErrorsDialog;

--- a/src/main/utils/finder.h
+++ b/src/main/utils/finder.h
@@ -27,7 +27,7 @@
 #include "../../core/subtitle.h"
 #include "../../core/subtitleline.h"
 
-#include <QtCore/QObject>
+#include <QObject>
 
 QT_FORWARD_DECLARE_CLASS(QGroupBox)
 QT_FORWARD_DECLARE_CLASS(QRadioButton)

--- a/src/main/utils/language.cpp
+++ b/src/main/utils/language.cpp
@@ -20,7 +20,7 @@
 
 #include "language.h"
 
-#include <QtCore/QFile>
+#include <QFile>
 #include <QStandardPaths>
 #include <QLocale>
 

--- a/src/main/utils/language.h
+++ b/src/main/utils/language.h
@@ -24,9 +24,9 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QMap>
-#include <QtCore/QList>
-#include <QtCore/QStringList>
+#include <QMap>
+#include <QList>
+#include <QStringList>
 
 namespace SubtitleComposer {
 class Language

--- a/src/main/utils/replacer.h
+++ b/src/main/utils/replacer.h
@@ -29,7 +29,7 @@
 #include "../../core/subtitle.h"
 #include "../../core/subtitleline.h"
 
-#include <QtCore/QObject>
+#include <QObject>
 
 QT_FORWARD_DECLARE_CLASS(QGroupBox)
 QT_FORWARD_DECLARE_CLASS(QRadioButton)

--- a/src/main/utils/speller.h
+++ b/src/main/utils/speller.h
@@ -28,7 +28,7 @@
 #include "../../core/subtitle.h"
 #include "../../core/subtitleline.h"
 
-#include <QtCore/QObject>
+#include <QObject>
 
 namespace Sonnet {
 class Dialog;

--- a/src/main/utils/translator.cpp
+++ b/src/main/utils/translator.cpp
@@ -21,8 +21,8 @@
 #include "translator.h"
 #include "../../common/qxtsignalwaiter.h"
 
-#include <QtCore/QRegExp>
-#include <QtCore/QTextCodec>
+#include <QRegExp>
+#include <QTextCodec>
 #include <QLabel>
 #include <QProgressBar>
 #include <QBoxLayout>

--- a/src/main/utils/translator.h
+++ b/src/main/utils/translator.h
@@ -27,9 +27,9 @@
 #include "language.h"
 #include "../dialogs/progressdialog.h"
 
-#include <QtCore/QObject>
-#include <QtCore/QMap>
-#include <QtCore/QByteArray>
+#include <QObject>
+#include <QMap>
+#include <QByteArray>
 
 class KJob;
 namespace KIO {

--- a/src/services/decoder.cpp
+++ b/src/services/decoder.cpp
@@ -28,8 +28,8 @@
 #include "xine/xinedecoderbackend.h"
 #endif
 
-#include <QtCore/QTimer>
-#include <QtCore/QFileInfo>
+#include <QTimer>
+#include <QFileInfo>
 
 #include <QDebug>
 

--- a/src/services/decoder.h
+++ b/src/services/decoder.h
@@ -27,7 +27,7 @@
 #include "service.h"
 #include "waveformat.h"
 
-#include <QtCore/QString>
+#include <QString>
 
 QT_FORWARD_DECLARE_CLASS(QTimer)
 

--- a/src/services/decoderbackend.h
+++ b/src/services/decoderbackend.h
@@ -29,8 +29,8 @@
 #include "decoder.h"
 #include "waveformat.h"
 
-#include <QtCore/QObject>
-#include <QtCore/QString>
+#include <QObject>
+#include <QString>
 #include <QWidget>
 
 namespace SubtitleComposer {

--- a/src/services/gstreamer/gstreamer.cpp
+++ b/src/services/gstreamer/gstreamer.cpp
@@ -20,7 +20,7 @@
 
 #include "gstreamer.h"
 
-#include <QtCore/QStringList>
+#include <QStringList>
 
 #include <QDebug>
 

--- a/src/services/gstreamer/gstreamer.h
+++ b/src/services/gstreamer/gstreamer.h
@@ -26,8 +26,8 @@
 
 #include "../waveformat.h"
 
-#include <QtCore/QString>
-#include <QtCore/QStringList>
+#include <QString>
+#include <QStringList>
 
 #include <gst/gst.h>
 

--- a/src/services/gstreamer/gstreamerdecoderbackend.cpp
+++ b/src/services/gstreamer/gstreamerdecoderbackend.cpp
@@ -22,7 +22,7 @@
 #include "gstreamerconfigwidget.h"
 #include "gstreamer.h"
 
-#include <QtCore/QTimer>
+#include <QTimer>
 
 #include <QDebug>
 

--- a/src/services/gstreamer/gstreamerdecoderbackend.h
+++ b/src/services/gstreamer/gstreamerdecoderbackend.h
@@ -29,7 +29,7 @@
 #include "../wavewriter.h"
 
 #include <QWidget>
-#include <QtCore/QString>
+#include <QString>
 
 #include <gst/gst.h>
 

--- a/src/services/gstreamer/gstreamerplayerbackend.cpp
+++ b/src/services/gstreamer/gstreamerplayerbackend.cpp
@@ -26,7 +26,7 @@
 
 #include <KLocalizedString>
 
-#include <QtCore/QTimer>
+#include <QTimer>
 
 #include <QDebug>
 #include <QUrl>

--- a/src/services/gstreamer/gstreamerplayerbackend.h
+++ b/src/services/gstreamer/gstreamerplayerbackend.h
@@ -28,7 +28,7 @@
 #include "../playerbackend.h"
 
 #include <QWidget>
-#include <QtCore/QString>
+#include <QString>
 
 #include <gst/gst.h>
 

--- a/src/services/mplayer/mediadata.h
+++ b/src/services/mplayer/mediadata.h
@@ -28,8 +28,8 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QString>
-#include <QtCore/QMap>
+#include <QString>
+#include <QMap>
 
 namespace SubtitleComposer {
 class TrackData

--- a/src/services/mplayer/mplayerplayerbackend.h
+++ b/src/services/mplayer/mplayerplayerbackend.h
@@ -28,7 +28,7 @@
 #include "../playerbackend.h"
 
 #include <QWidget>
-#include <QtCore/QString>
+#include <QString>
 
 namespace SubtitleComposer {
 class MPlayerPlayerProcess;

--- a/src/services/mplayer/mplayerplayerprocess.cpp
+++ b/src/services/mplayer/mplayerplayerprocess.cpp
@@ -25,7 +25,7 @@
 
 #include <QApplication>
 #include <QStandardPaths>
-#include <QtCore/QStringList>
+#include <QStringList>
 
 #include <QDebug>
 

--- a/src/services/mplayer/mplayerplayerprocess.h
+++ b/src/services/mplayer/mplayerplayerprocess.h
@@ -27,13 +27,13 @@
 
 #include "mediadata.h"
 
-#include <QtCore/QObject>
-#include <QtCore/QString>
-#include <QtCore/QRegExp>
-#include <QtCore/QByteArray>
-#include <QtCore/QList>
-#include <QtCore/QTimer>
-#include <QtCore/QProcess>
+#include <QObject>
+#include <QString>
+#include <QRegExp>
+#include <QByteArray>
+#include <QList>
+#include <QTimer>
+#include <QProcess>
 
 namespace SubtitleComposer {
 class MPlayerPlayerProcess : public QProcess

--- a/src/services/mpv/mpvbackend.h
+++ b/src/services/mpv/mpvbackend.h
@@ -30,7 +30,7 @@
 #include <mpv/qthelper.hpp>
 
 #include <QWidget>
-#include <QtCore/QString>
+#include <QString>
 
 namespace SubtitleComposer {
 class MPVProcess;

--- a/src/services/phonon/phononplayerbackend.h
+++ b/src/services/phonon/phononplayerbackend.h
@@ -27,8 +27,8 @@
 
 #include "../playerbackend.h"
 
-#include <QtCore/QString>
-#include <QtCore/QTextStream>   // NOTE this is only here because Qt complains otherwise when including Phonon/Global...
+#include <QString>
+#include <QTextStream>   // NOTE this is only here because Qt complains otherwise when including Phonon/Global...
 #include <QWidget>
 #include <KDE/Phonon/Global>
 

--- a/src/services/player.cpp
+++ b/src/services/player.cpp
@@ -35,8 +35,8 @@
 
 #include <math.h>
 
-#include <QtCore/QTimer>
-#include <QtCore/QFileInfo>
+#include <QTimer>
+#include <QFileInfo>
 #include <QApplication>
 #include <QEvent>
 

--- a/src/services/player.h
+++ b/src/services/player.h
@@ -27,9 +27,9 @@
 #include "service.h"
 #include "videowidget.h"
 
-#include <QtCore/QString>
-#include <QtCore/QStringList>
-#include <QtCore/QMap>
+#include <QString>
+#include <QStringList>
+#include <QMap>
 #include <QWidget>
 
 QT_FORWARD_DECLARE_CLASS(QTimer)

--- a/src/services/playerbackend.h
+++ b/src/services/playerbackend.h
@@ -28,8 +28,8 @@
 #include "servicebackend.h"
 #include "player.h"
 
-#include <QtCore/QObject>
-#include <QtCore/QString>
+#include <QObject>
+#include <QString>
 #include <QWidget>
 
 namespace SubtitleComposer {

--- a/src/services/service.h
+++ b/src/services/service.h
@@ -25,9 +25,9 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QString>
-#include <QtCore/QStringList>
-#include <QtCore/QMap>
+#include <QString>
+#include <QStringList>
+#include <QMap>
 #include <QWidget>
 
 namespace SubtitleComposer {

--- a/src/services/servicebackend.h
+++ b/src/services/servicebackend.h
@@ -27,8 +27,8 @@
 
 #include "service.h"
 
-#include <QtCore/QObject>
-#include <QtCore/QString>
+#include <QObject>
+#include <QString>
 #include <QWidget>
 
 namespace SubtitleComposer {

--- a/src/services/tests/wavewritertest.h
+++ b/src/services/tests/wavewritertest.h
@@ -24,7 +24,7 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QObject>
+#include <QObject>
 
 class WaveWriterTest : public QObject
 {

--- a/src/services/videowidget.h
+++ b/src/services/videowidget.h
@@ -24,8 +24,8 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QPoint>
-#include <QtCore/QSize>
+#include <QPoint>
+#include <QSize>
 #include <QWidget>
 
 QT_FORWARD_DECLARE_CLASS(QResizeEvent)

--- a/src/services/waveformat.h
+++ b/src/services/waveformat.h
@@ -24,7 +24,7 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QString>
+#include <QString>
 
 class WaveFormat
 {

--- a/src/services/wavewriter.h
+++ b/src/services/wavewriter.h
@@ -27,7 +27,7 @@
 #include "waveformat.h"
 
 #include <stdio.h>
-#include <QtCore/QString>
+#include <QString>
 
 class WaveWriter
 {

--- a/src/services/xine/xinedecoderbackend.cpp
+++ b/src/services/xine/xinedecoderbackend.cpp
@@ -22,11 +22,11 @@
 #include "xineconfigwidget.h"
 #include "../wavewriter.h"
 
-#include <QtCore/QEvent>
-#include <QtCore/QDir>
-#include <QtCore/QFile>
-#include <QtCore/QThread>
-#include <QtCore/QCoreApplication>
+#include <QEvent>
+#include <QDir>
+#include <QFile>
+#include <QThread>
+#include <QCoreApplication>
 #include <QDebug>
 #include <QUrl>
 

--- a/src/services/xine/xinedecoderbackend.h
+++ b/src/services/xine/xinedecoderbackend.h
@@ -27,7 +27,7 @@
 
 #include "../decoderbackend.h"
 
-#include <QtCore/QString>
+#include <QString>
 
 #define XINE_ENABLE_EXPERIMENTAL_FEATURES
 #include <xine.h>

--- a/src/services/xine/xineplayerbackend.cpp
+++ b/src/services/xine/xineplayerbackend.cpp
@@ -24,10 +24,10 @@
 
 #include "../../main/application.h"
 
-#include <QtCore/QEventLoop>
-#include <QtCore/QEvent>
-#include <QtCore/QDir>
-#include <QtCore/QFile>
+#include <QEventLoop>
+#include <QEvent>
+#include <QDir>
+#include <QFile>
 #include <QApplication>
 #include <QDebug>
 #include <QUrl>

--- a/src/services/xine/xineplayerbackend.h
+++ b/src/services/xine/xineplayerbackend.h
@@ -27,9 +27,9 @@
 
 #include "../playerbackend.h"
 
-#include <QtCore/QString>
-#include <QtCore/QRect>
-#include <QtCore/QTimer>
+#include <QString>
+#include <QRect>
+#include <QTimer>
 #include <QWidget>
 
 #include <xine.h>

--- a/src/widgets/attachablewidget.cpp
+++ b/src/widgets/attachablewidget.cpp
@@ -23,8 +23,8 @@
 
 #include "attachablewidget.h"
 
-#include <QtCore/QEvent>
-#include <QtCore/QTimerEvent>
+#include <QEvent>
+#include <QTimerEvent>
 #include <QMouseEvent>
 
 #include <QDebug>

--- a/src/widgets/layeredwidget.h
+++ b/src/widgets/layeredwidget.h
@@ -25,7 +25,7 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QList>
+#include <QList>
 #include <QWidget>
 
 /// a class used to show varios widgets simultaneously one in top

--- a/src/widgets/simplerichtextedit.cpp
+++ b/src/widgets/simplerichtextedit.cpp
@@ -22,8 +22,8 @@
 
 #include "../main/dialogs/subtitlecolordialog.h"
 
-#include <QtCore/QRegExp>
-#include <QtCore/QEvent>
+#include <QRegExp>
+#include <QEvent>
 #include <QMenu>
 #include <QShortcutEvent>
 #include <QContextMenuEvent>

--- a/src/widgets/textoverlaywidget.cpp
+++ b/src/widgets/textoverlaywidget.cpp
@@ -20,7 +20,7 @@
 
 #include "textoverlaywidget.h"
 
-#include <QtCore/QCoreApplication>
+#include <QCoreApplication>
 #include <QPainter>
 #include <QTextDocument>
 #include <QAbstractTextDocumentLayout>

--- a/src/widgets/timeedit.cpp
+++ b/src/widgets/timeedit.cpp
@@ -21,8 +21,8 @@
 #include "timeedit.h"
 #include "timevalidator.h"
 
-#include <QtCore/QTime>
-#include <QtCore/QEvent>
+#include <QTime>
+#include <QEvent>
 #include <QKeyEvent>
 
 #include <QDebug>

--- a/src/widgets/timevalidator.h
+++ b/src/widgets/timevalidator.h
@@ -24,7 +24,7 @@
 #include <config.h>
 #endif
 
-#include <QtCore/QString>
+#include <QString>
 #include <QValidator>
 
 // class TimeValidator : public QRegExpValidator

--- a/src/widgets/treeview.cpp
+++ b/src/widgets/treeview.cpp
@@ -19,7 +19,7 @@
 
 #include "treeview.h"
 
-#include <QtCore/QTimer>
+#include <QTimer>
 #include <QScrollBar>
 
 TreeView::TreeView(QWidget *parent) :


### PR DESCRIPTION
- Removed "QtCore/"-prefix from includes hence
  this is the right way to include Qt classes.
- Removed useless code.