### PR TITLE
Explicitly link with X11

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,8 @@ set_package_properties(Phonon4Qt5 PROPERTIES
    DESCRIPTION "Qt-based audio library"
    TYPE REQUIRED)
 
+find_package(X11 REQUIRED)
+
 # the subdirs must be added in a specific order
 # if one dir uses code from another, its CMakeLists.txt will reference variables
 # defined in the dependency directory that must be created before the former

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -50,7 +50,7 @@ target_link_libraries(subtitlecomposer
 	${videoplayer_LIBS}
 	${streamprocessor_LIBS}
 	${widgets_LIBS}
-	-lX11 # xine needs XInitThreads() call in main
+	${X11_LIBRARIES} # xine needs XInitThreads() call in main
 )
 
 add_definitions(

--- a/src/videoplayerplugins/xine/CMakeLists.txt
+++ b/src/videoplayerplugins/xine/CMakeLists.txt
@@ -8,7 +8,7 @@ set(videoplayer_xine_DEFS
 )
 set(videoplayer_xine_LIBS
 	${XINE_LIBRARY}
-	-lX11
+	${X11_LIBRARIES}
 	CACHE INTERNAL EXPORTEDVARIABLE
 )
 set(videoplayer_xine_SRCS


### PR DESCRIPTION
Use the `FindX11.cmake` module to make sure X11 is available, and use its variable when linking to it.

This just makes the X11 dependency explicit, instead of a less visible `-lX11` in `target_link_libraries()` calls.