### PR TITLE
Fix unsynched numbering of lines and waveforms

### DIFF
--- a/src/widgets/waveformwidget.cpp
+++ b/src/widgets/waveformwidget.cpp
@@ -556,9 +556,9 @@ WaveformWidget::paintGraphics(QPainter &painter)
 			painter.setPen(m_subNumberColor);
 			painter.setFont(m_fontNumber);
 			if(m_vertical)
-				painter.drawText(m_fontNumberHeight / 2, showY + m_fontNumberHeight + 2, QString::number(sub->index() + 1));
+				painter.drawText(m_fontNumberHeight / 2, showY + m_fontNumberHeight + 2, QString::number(sub->index() + 2));
 			else
-				painter.drawText(showY + m_fontNumberHeight / 2, m_fontNumberHeight + 2, QString::number(sub->index() + 1));
+				painter.drawText(showY + m_fontNumberHeight / 2, m_fontNumberHeight + 2, QString::number(sub->index() + 2));
 		}
 	}
 


### PR DESCRIPTION
Maybe this is a fix for the last part of issue #53 
"Also, counting of the lines starts at 0 rather than 1 in the waveform."
It was unsynched numbering of lines of titles and number of waveform. Lines are starting from 1, but waveforms starts from 0. So when editing subtitles it is uncomfortable to watch different numbers related to same text.