### PR TITLE
Fix m_dialogueRegExp in ASS input format

### DIFF
--- a/src/formats/format.h
+++ b/src/formats/format.h
@@ -20,10 +20,6 @@
  *   Boston, MA 02110-1301, USA.                                           *
  ***************************************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "../core/formatdata.h"
 #include "../core/subtitle.h"
 #include "../core/subtitleline.h"
@@ -64,10 +60,10 @@ public:
 
 	bool knowsExtension(const QString &extension) const
 	{
-		QString ext = extension.toLower();
-		for(QStringList::ConstIterator it = m_extensions.begin(), end = m_extensions.end(); it != end; ++it) {
-			if(*it == ext && *it != "*")
+		for(const QString &knownExtension : m_extensions) {
+			if(knownExtension != QChar('*') && knownExtension.compare(extension, Qt::CaseInsensitive) == 0) {
 				return true;
+			}
 		}
 		return false;
 	}
@@ -81,7 +77,7 @@ protected:
 	FormatData * formatData(const Subtitle &subtitle) const
 	{
 		FormatData *formatData = subtitle.formatData();
-		return formatData && formatData->formatName() == m_name ? formatData : 0;
+		return formatData && formatData->formatName() == m_name ? formatData : nullptr;
 	}
 
 	void setFormatData(Subtitle &subtitle, FormatData *formatData) const
@@ -97,7 +93,7 @@ protected:
 	FormatData * formatData(const SubtitleLine *line) const
 	{
 		FormatData *formatData = line->formatData();
-		return formatData && formatData->formatName() == m_name ? formatData : 0;
+		return formatData && formatData->formatName() == m_name ? formatData : nullptr;
 	}
 
 	void setFormatData(SubtitleLine *line, FormatData *formatData) const

--- a/src/formats/formatmanager.h
+++ b/src/formats/formatmanager.h
@@ -20,10 +20,6 @@
  *   Boston, MA 02110-1301, USA.                                           *
  ***************************************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "inputformat.h"
 #include "outputformat.h"
 

--- a/src/formats/inputformat.h
+++ b/src/formats/inputformat.h
@@ -20,10 +20,6 @@
  *   Boston, MA 02110-1301, USA.                                           *
  ***************************************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "format.h"
 
 namespace SubtitleComposer {

--- a/src/formats/microdvd/microdvdinputformat.h
+++ b/src/formats/microdvd/microdvdinputformat.h
@@ -20,10 +20,6 @@
  *   Boston, MA 02110-1301, USA.                                           *
  ***************************************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "../inputformat.h"
 
 #include <QRegExp>
@@ -62,8 +58,8 @@ protected:
 		do {
 			offset += m_lineRegExp.matchedLength();
 
-			Time showTime((long)((m_lineRegExp.cap(1).toLong() / framesPerSecond) * 1000));
-			Time hideTime((long)((m_lineRegExp.cap(2).toLong() / framesPerSecond) * 1000));
+                        Time showTime(static_cast<long>((m_lineRegExp.cap(1).toLong() / framesPerSecond) * 1000));
+                        Time hideTime(static_cast<long>((m_lineRegExp.cap(2).toLong() / framesPerSecond) * 1000));
 
 			SString richText;
 
@@ -78,9 +74,9 @@ protected:
 				int newStyle = currentStyle;
 				QRgb newColor = currentColor;
 
-				if(tag == QLatin1String("Y")) {
+                                if(tag == QChar('Y')) {
 					globalStyle = 0;
-					if(val.contains('b'))
+                                        if(val.contains('b'))
 						globalStyle |= SString::Bold;
 					if(val.contains('i'))
 						globalStyle |= SString::Italic;
@@ -134,8 +130,8 @@ protected:
 
 	MicroDVDInputFormat() :
 		InputFormat(QStringLiteral("MicroDVD"), QStringList() << QStringLiteral("sub") << QStringLiteral("txt")),
-		m_lineRegExp("\\{(\\d+)\\}\\{(\\d+)\\}([^\n]+)\n", Qt::CaseInsensitive),
-		m_styleRegExp("\\{([yc]):([^}]*)\\}", Qt::CaseInsensitive)
+                m_lineRegExp(QStringLiteral("\\{(\\d+)\\}\\{(\\d+)\\}([^\n]+)\n"), Qt::CaseInsensitive),
+                m_styleRegExp(QStringLiteral("\\{([yc]):([^}]*)\\}"), Qt::CaseInsensitive)
 	{}
 
 	mutable QRegExp m_lineRegExp;

--- a/src/formats/microdvd/microdvdoutputformat.h
+++ b/src/formats/microdvd/microdvdoutputformat.h
@@ -20,10 +20,6 @@
  *   Boston, MA 02110-1301, USA.                                           *
  ***************************************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "../outputformat.h"
 #include "../../core/subtitleiterator.h"
 
@@ -51,7 +47,7 @@ protected:
 			const SubtitleLine *line = it.current();
 
 			const SString &text = primary ? line->primaryText() : line->secondaryText();
-			QString subtitle = "";
+                        QString subtitle;
 
 			int prevStyle = 0;
 			QRgb prevColor = 0;
@@ -75,8 +71,8 @@ protected:
 			}
 
 			ret += m_lineBuilder
-					.arg((long)((line->showTime().toMillis() / 1000.0) * framesPerSecond + 0.5))
-					.arg((long)((line->hideTime().toMillis() / 1000.0) * framesPerSecond + 0.5))
+                                        .arg(static_cast<long>((line->showTime().toMillis() / 1000.0) * framesPerSecond + 0.5))
+                                        .arg(static_cast<long>((line->hideTime().toMillis() / 1000.0) * framesPerSecond + 0.5))
 					.arg(subtitle);
 		}
 		return ret;
@@ -84,16 +80,16 @@ protected:
 
 	MicroDVDOutputFormat() :
 		OutputFormat(QStringLiteral("MicroDVD"), QStringList() << QStringLiteral("sub") << QStringLiteral("txt")),
-		m_lineBuilder("{%1}{%2}%3\n")
+                m_lineBuilder(QStringLiteral("{%1}{%2}%3\n"))
 	{
-		m_stylesMap[0] = "{y:}";
-		m_stylesMap[SString::Bold] = "{y:b}";
-		m_stylesMap[SString::Italic] = "{y:i}";
-		m_stylesMap[SString::Underline] = "{y:u}";
-		m_stylesMap[SString::Bold | SString::Italic] = "{y:b,i}";
-		m_stylesMap[SString::Bold | SString::Underline] = "{y:u,b}";
-		m_stylesMap[SString::Italic | SString::Underline] = "{y:u,i}";
-		m_stylesMap[SString::Bold | SString::Italic | SString::Underline] = "{y:u,b,i}";
+                m_stylesMap[0] = QStringLiteral("{y:}");
+                m_stylesMap[SString::Bold] = QStringLiteral("{y:b}");
+                m_stylesMap[SString::Italic] = QStringLiteral("{y:i}");
+                m_stylesMap[SString::Underline] = QStringLiteral("{y:u}");
+                m_stylesMap[SString::Bold | SString::Italic] = QStringLiteral("{y:b,i}");
+                m_stylesMap[SString::Bold | SString::Underline] = QStringLiteral("{y:u,b}");
+                m_stylesMap[SString::Italic | SString::Underline] = QStringLiteral("{y:u,i}");
+                m_stylesMap[SString::Bold | SString::Italic | SString::Underline] = QStringLiteral("{y:u,b,i}");
 	}
 
 	const QString m_lineBuilder;

--- a/src/formats/mplayer/mplayerinputformat.h
+++ b/src/formats/mplayer/mplayerinputformat.h
@@ -20,10 +20,6 @@
  *   Boston, MA 02110-1301, USA.                                           *
  ***************************************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "../inputformat.h"
 
 #include <QRegExp>
@@ -41,8 +37,8 @@ protected:
 		unsigned readLines = 0;
 
 		for(int offset = 0; m_lineRegExp.indexIn(data, offset) != -1; offset += m_lineRegExp.matchedLength()) {
-			Time showTime((long)((m_lineRegExp.cap(1).toLong() / framesPerSecond) * 1000));
-			Time hideTime((long)((m_lineRegExp.cap(2).toLong() / framesPerSecond) * 1000));
+			Time showTime(static_cast<long>((m_lineRegExp.cap(1).toLong() / framesPerSecond) * 1000));
+			Time hideTime(static_cast<long>((m_lineRegExp.cap(2).toLong() / framesPerSecond) * 1000));
 			QString text(m_lineRegExp.cap(3).replace("|", "\n"));
 
 			subtitle.insertLine(new SubtitleLine(text, showTime, hideTime));
@@ -53,8 +49,8 @@ protected:
 	}
 
 	MPlayerInputFormat() :
-		InputFormat("MPlayer", QStringList("mpl")),
-		m_lineRegExp("(^|\n)(\\d+),(\\d+),0,([^\n]+)[^\n]")
+		InputFormat(QStringLiteral("MPlayer"), QStringList(QStringLiteral("mpl"))),
+		m_lineRegExp(QStringLiteral("(^|\n)(\\d+),(\\d+),0,([^\n]+)[^\n]"))
 	{}
 
 	mutable QRegExp m_lineRegExp;

--- a/src/formats/mplayer/mplayeroutputformat.h
+++ b/src/formats/mplayer/mplayeroutputformat.h
@@ -20,10 +20,6 @@
  *   Boston, MA 02110-1301, USA.                                           *
  ***************************************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "../outputformat.h"
 #include "../../core/subtitleiterator.h"
 
@@ -44,16 +40,16 @@ protected:
 
 			const SString &text = primary ? line->primaryText() : line->secondaryText();
 
-			ret += m_lineBuilder.arg((long)((line->showTime().toMillis() / 1000.0) * framesPerSecond + 0.5))
-					.arg((long)((line->hideTime().toMillis() / 1000.0) * framesPerSecond + 0.5))
+			ret += m_lineBuilder.arg(static_cast<long>((line->showTime().toMillis() / 1000.0) * framesPerSecond + 0.5))
+					.arg(static_cast<long>((line->hideTime().toMillis() / 1000.0) * framesPerSecond + 0.5))
 					.arg(text.string().replace('\n', '|'));
 		}
 		return ret;
 	}
 
 	MPlayerOutputFormat() :
-		OutputFormat("MPlayer", QStringList("mpl")),
-		m_lineBuilder("%1,%2,0,%3\n")
+		OutputFormat(QStringLiteral("MPlayer"), QStringList(QStringLiteral("mpl"))),
+		m_lineBuilder(QStringLiteral("%1,%2,0,%3\n"))
 	{}
 
 	const QString m_lineBuilder;

--- a/src/formats/mplayer2/mplayer2inputformat.h
+++ b/src/formats/mplayer2/mplayer2inputformat.h
@@ -20,10 +20,6 @@
  *   Boston, MA 02110-1301, USA.                                           *
  ***************************************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "../inputformat.h"
 
 #include <QRegExp>
@@ -41,7 +37,7 @@ protected:
 		for(int offset = 0; m_lineRegExp.indexIn(data, offset) != -1; offset += m_lineRegExp.matchedLength()) {
 			Time showTime(m_lineRegExp.cap(1).toInt() * 100);
 			Time hideTime(m_lineRegExp.cap(2).toInt() * 100);
-			QString text(m_lineRegExp.cap(3).replace("|", "\n"));
+			QString text(m_lineRegExp.cap(3).replace('|', '\n'));
 
 			subtitle.insertLine(new SubtitleLine(text, showTime, hideTime));
 
@@ -51,8 +47,8 @@ protected:
 	}
 
 	MPlayer2InputFormat() :
-		InputFormat("MPlayer2", QStringList("mpl")),
-		m_lineRegExp("\\[(\\d+)\\]\\[(\\d+)\\]([^\n]+)\n")
+		InputFormat(QStringLiteral("MPlayer2"), QStringList(QStringLiteral("mpl"))),
+		m_lineRegExp(QStringLiteral("\\[(\\d+)\\]\\[(\\d+)\\]([^\n]+)\n"))
 	{}
 
 	mutable QRegExp m_lineRegExp;

--- a/src/formats/mplayer2/mplayer2outputformat.h
+++ b/src/formats/mplayer2/mplayer2outputformat.h
@@ -20,10 +20,6 @@
  *   Boston, MA 02110-1301, USA.                                           *
  ***************************************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "../outputformat.h"
 #include "../../core/subtitleiterator.h"
 
@@ -42,16 +38,16 @@ protected:
 
 			const SString &text = primary ? line->primaryText() : line->secondaryText();
 
-			ret += m_lineBuilder.arg((long)((line->showTime().toMillis() / 100.0) + 0.5))
-					.arg((long)((line->hideTime().toMillis() / 100.0) + 0.5))
+			ret += m_lineBuilder.arg(static_cast<long>((line->showTime().toMillis() / 100.0) + 0.5))
+					.arg(static_cast<long>((line->hideTime().toMillis() / 100.0) + 0.5))
 					.arg(text.string().replace('\n', '|'));
 		}
 		return ret;
 	}
 
 	MPlayer2OutputFormat() :
-		OutputFormat("MPlayer2", QStringList("mpl")),
-		m_lineBuilder("[%1][%2]%3\n")
+		OutputFormat(QStringLiteral("MPlayer2"), QStringList(QStringLiteral("mpl"))),
+		m_lineBuilder(QStringLiteral("[%1][%2]%3\n"))
 	{}
 
 	const QString m_lineBuilder;

--- a/src/formats/outputformat.h
+++ b/src/formats/outputformat.h
@@ -20,10 +20,6 @@
  *   Boston, MA 02110-1301, USA.                                           *
  ***************************************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "format.h"
 namespace SubtitleComposer {
 class OutputFormat : public Format

--- a/src/formats/subrip/subripinputformat.h
+++ b/src/formats/subrip/subripinputformat.h
@@ -48,7 +48,7 @@ protected:
 
 			offset += m_regExp.matchedLength();
 
-			QString text(data.mid(offset, (unsigned)m_regExp.indexIn(data, offset) - offset));
+			QString text(data.mid(offset, m_regExp.indexIn(data, offset) - offset));
 
 			offset += text.length();
 
@@ -64,8 +64,8 @@ protected:
 	}
 
 	SubRipInputFormat() :
-		InputFormat("SubRip", QStringList("srt")),
-		m_regExp("[\\d]+\n([0-2][0-9]):([0-5][0-9]):([0-5][0-9])[,\\.]([0-9][0-9][0-9]) --> ([0-2][0-9]):([0-5][0-9]):([0-5][0-9])[,\\.]([0-9][0-9][0-9])\n")
+		InputFormat(QStringLiteral("SubRip"), QStringList(QStringLiteral("srt"))),
+		m_regExp(QStringLiteral("[\\d]+\n([0-2][0-9]):([0-5][0-9]):([0-5][0-9])[,\\.]([0-9][0-9][0-9]) --> ([0-2][0-9]):([0-5][0-9]):([0-5][0-9])[,\\.]([0-9][0-9][0-9])\n"))
 	{}
 
 	mutable QRegExp m_regExp;

--- a/src/formats/subrip/subripoutputformat.h
+++ b/src/formats/subrip/subripoutputformat.h
@@ -46,16 +46,16 @@ protected:
 
 			const SString &text = primary ? line->primaryText() : line->secondaryText();
 
-			ret += text.richString().replace("&amp;", ">").replace("&lt;", "<").replace("&gt;", ">");
+			ret += text.richString().replace(QLatin1String("&amp;"), QLatin1String(">")).replace(QLatin1String("&lt;"), QLatin1String("<")).replace(QLatin1String("&gt;"), QLatin1String(">"));
 
-			ret += "\n\n";
+			ret += QStringLiteral("\n\n");
 		}
 		return ret;
 	}
 
 	SubRipOutputFormat() :
-		OutputFormat("SubRip", QStringList("srt")),
-		m_dialogueBuilder("%1%2%3%4%5%6%7\n\n")
+		OutputFormat(QStringLiteral("SubRip"), QStringList(QStringLiteral("srt"))),
+		m_dialogueBuilder(QStringLiteral("%1%2%3%4%5%6%7\n\n"))
 	{}
 
 	const QString m_dialogueBuilder;

--- a/src/formats/substationalpha/substationalphainputformat.h
+++ b/src/formats/substationalpha/substationalphainputformat.h
@@ -20,13 +20,10 @@
  *   Boston, MA 02110-1301, USA.                                           *
  ***************************************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "../inputformat.h"
 
 #include <QRegExp>
+#include <QStringBuilder>
 
 namespace SubtitleComposer {
 class SubStationAlphaInputFormat : public InputFormat
@@ -37,12 +34,12 @@ class SubStationAlphaInputFormat : public InputFormat
 protected:
 	SString toSString(QString string) const
 	{
-		static QRegExp cmdRegExp("\\{([^\\}]+)\\}");
+		static const QRegExp cmdRegExp(QStringLiteral("\\{([^\\}]+)\\}"));
 
 		SString ret;
 
-		string.replace("\\N", "\n");
-		string.replace("\\n", "\n");
+		string.replace(QLatin1String("\\N"), QLatin1String("\n"));
+		string.replace(QLatin1String("\\n"), QLatin1String("\n"));
 
 		int currentStyle = 0;
 		QRgb currentColor = 0;
@@ -71,13 +68,13 @@ protected:
 				} else if(*it == QLatin1String("u1")) {
 					newStyleFlags |= SString::Underline;
 				} else if(it->at(0) == 'c') {
-					QString val = ("000000" + it->mid(3, -2)).right(6);
+					QString val = (QStringLiteral("000000") + it->mid(3, -2)).right(6);
 					if(val == QLatin1String("000000")) {
 						newStyleFlags &= ~SString::Color;
 						newColor = 0;
 					} else {
 						newStyleFlags |= SString::Color;
-						newColor = QColor("#" + val.mid(4, 2) + val.mid(2, 2) + val.mid(0, 2)).rgb();
+						newColor = QColor(QChar('#') % val.mid(4, 2) % val.mid(2, 2) % val.mid(0, 2)).rgb();
 					}
 				}
 			}
@@ -132,28 +129,28 @@ protected:
 
 			SubtitleLine *line = new SubtitleLine(toSString(m_dialogueRegExp.cap(3)), showTime, hideTime);
 
-			formatData.setValue("Dialogue", m_dialogueRegExp.cap(0).replace(m_dialogueDataRegExp, "\\1%1\\2%2\\3%3\n"));
+			formatData.setValue(QStringLiteral("Dialogue"), m_dialogueRegExp.cap(0).replace(m_dialogueDataRegExp, "\\1%1\\2%2\\3%3\n"));
 			setFormatData(line, formatData);
 
 			subtitle.insertLine(line);
 
 			readLines++;
 		}
-		return readLines > 0;
+		return readLines;
 	}
 
 	SubStationAlphaInputFormat(
-			const QString &name = "SubStation Alpha",
-			const QStringList &extensions = QStringList("ssa"),
-			const QString &stylesRegExp = s_stylesRegExp) :
+			const QString &name = QStringLiteral("SubStation Alpha"),
+			const QStringList &extensions = QStringList(QStringLiteral("ssa")),
+			const QString &stylesRegExp = QStringLiteral("[\r\n]+ *\\[[vV]4 Styles\\] *[\r\n]+")) :
 		InputFormat(name, extensions),
-		m_scriptInfoRegExp(s_scriptInfoRegExp),
+		m_scriptInfoRegExp(QStringLiteral("^ *\\[Script Info\\] *[\r\n]+")),
 		m_stylesRegExp(stylesRegExp),
-		m_eventsRegExp(s_eventsRegExp),
-		m_formatRegExp(s_formatRegExp),
-		m_dialogueRegExp(s_dialogueRegExp),
-		m_dialogueDataRegExp(s_dialogueDataRegExp),
-		m_timeRegExp(s_timeRegExp)
+		m_eventsRegExp(QStringLiteral("[\r\n]+ *\\[Events\\] *[\r\n]+")),
+		m_formatRegExp(QStringLiteral(" *Format: *(\\w+,? *)+[\r\n]+")),
+		m_dialogueRegExp(QStringLiteral(" *Dialogue: *[^,]+, *([^,]+), *([^,]+), *[^,]*, *[^,]*, *[^,]*, *[^,]*, *[^,]*, *[^,]*, *([^\r\n]*)[\r\n]+")),
+		m_dialogueDataRegExp(QStringLiteral(" *(Dialogue: *[^,]+, *)[^,]+(, *)[^,]+(, *[^,]+, *[^,]*, *[^,]*, *[^,]*, *[^,]*, *[^,]*, *).*")),
+		m_timeRegExp(QStringLiteral("(\\d+):(\\d+):(\\d+).(\\d+)"))
 	{}
 
 	mutable QRegExp m_scriptInfoRegExp;
@@ -163,23 +160,7 @@ protected:
 	mutable QRegExp m_dialogueRegExp;
 	mutable QRegExp m_dialogueDataRegExp;
 	mutable QRegExp m_timeRegExp;
-
-	static const char *s_scriptInfoRegExp;
-	static const char *s_stylesRegExp;
-	static const char *s_formatRegExp;
-	static const char *s_eventsRegExp;
-	static const char *s_dialogueRegExp;
-	static const char *s_dialogueDataRegExp;
-	static const char *s_timeRegExp;
 };
-
-const char *SubStationAlphaInputFormat::s_scriptInfoRegExp = "^ *\\[Script Info\\] *[\r\n]+";
-const char *SubStationAlphaInputFormat::s_stylesRegExp = "[\r\n]+ *\\[[vV]4 Styles\\] *[\r\n]+";
-const char *SubStationAlphaInputFormat::s_formatRegExp = " *Format: *(\\w+,? *)+[\r\n]+";
-const char *SubStationAlphaInputFormat::s_eventsRegExp = "[\r\n]+ *\\[Events\\] *[\r\n]+";
-const char *SubStationAlphaInputFormat::s_dialogueRegExp = " *Dialogue: *[^,]+, *([^,]+), *([^,]+), *[^,]+, *[^,]*, *\\d{4}, *\\d{4}, *\\d{4}, *[^,]*, *([^\r\n]*)[\r\n]+";
-const char *SubStationAlphaInputFormat::s_dialogueDataRegExp = " *(Dialogue: *[^,]+, *)[^,]+(, *)[^,]+(, *[^,]+, *[^,]*, *\\d{4}, *\\d{4}, *\\d{4}, *[^,]*, *).*";
-const char *SubStationAlphaInputFormat::s_timeRegExp = "(\\d+):(\\d+):(\\d+).(\\d+)";
 
 class AdvancedSubStationAlphaInputFormat : public SubStationAlphaInputFormat
 {
@@ -187,7 +168,7 @@ class AdvancedSubStationAlphaInputFormat : public SubStationAlphaInputFormat
 
 protected:
 	AdvancedSubStationAlphaInputFormat() :
-		SubStationAlphaInputFormat("Advanced SubStation Alpha", QStringList("ass"), "[\r\n]+ *\\[[vV]4\\+ Styles\\] *[\r\n]+")
+		SubStationAlphaInputFormat(QStringLiteral("Advanced SubStation Alpha"), QStringList(QStringLiteral("ass")), "[\r\n]+ *\\[[vV]4\\+ Styles\\] *[\r\n]+")
 	{}
 };
 

--- a/src/formats/substationalpha/substationalphaoutputformat.h
+++ b/src/formats/substationalpha/substationalphaoutputformat.h
@@ -20,10 +20,6 @@
  *   Boston, MA 02110-1301, USA.                                           *
  ***************************************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "../outputformat.h"
 #include "../../core/formatdata.h"
 #include "../../core/subtitleiterator.h"
@@ -37,7 +33,7 @@ public:
 	QString fromSString(const SString &text) const
 	{
 
-		QString subtitle = "";
+		QString subtitle;
 
 		int prevStyle = 0;
 		QRgb prevColor = 0;
@@ -47,25 +43,25 @@ public:
 			curStyle &= SString::Bold | SString::Italic | SString::Underline;
 			if(prevStyle != curStyle) {
 				int diff = curStyle ^ prevStyle;
-				subtitle += "{";
+				subtitle += '{';
 				if(diff & SString::Bold)
-					subtitle += curStyle & SString::Bold ? "\\b1" : "\\b0";
+					subtitle += curStyle & SString::Bold ? QStringLiteral("\\b1") : QStringLiteral("\\b0");
 				if(diff & SString::Italic)
-					subtitle += curStyle & SString::Italic ? "\\i1" : "\\i0";
+					subtitle += curStyle & SString::Italic ? QStringLiteral("\\i1") : QStringLiteral("\\i0");
 				if(diff & SString::Underline)
-					subtitle += curStyle & SString::Underline ? "\\u1" : "\\u0";
+					subtitle += curStyle & SString::Underline ? QStringLiteral("\\u1") : QStringLiteral("\\u0");
 				subtitle += "}";
 			}
 			if(prevColor != curColor) {
-				subtitle += "{\\c&H";
+				subtitle += QStringLiteral("{\\c&H");
 				if(curColor != 0) {
-					subtitle += ("0" + QString::number(qBlue(curColor), 16)).toUpper().right(2);
-					subtitle += ("0" + QString::number(qGreen(curColor), 16)).toUpper().right(2);
-					subtitle += ("0" + QString::number(qRed(curColor), 16)).toUpper().right(2);
+					subtitle += (QChar('0') + QString::number(qBlue(curColor), 16)).toUpper().right(2);
+					subtitle += (QChar('0') + QString::number(qGreen(curColor), 16)).toUpper().right(2);
+					subtitle += (QChar('0') + QString::number(qRed(curColor), 16)).toUpper().right(2);
 				} else {
-					subtitle += "00";
+					subtitle += QStringLiteral("00");
 				}
-				subtitle += "&}";
+				subtitle += QStringLiteral("&}");
 			}
 
 			subtitle += text.at(i);
@@ -75,19 +71,19 @@ public:
 		}
 
 		if(prevStyle) {
-			subtitle += "{";
+			subtitle +='{';
 			if(prevStyle & SString::Bold)
-				subtitle += "\\b0";
+				subtitle += QStringLiteral("\\b0");
 			if(prevStyle & SString::Italic)
-				subtitle += "\\i0";
+				subtitle += QStringLiteral("\\i0");
 			if(prevStyle & SString::Underline)
-				subtitle += "\\u0";
-			subtitle += "}";
+				subtitle += QStringLiteral("\\u0");
+			subtitle += '}';
 		}
 
-		subtitle = subtitle.replace("\r\n", "\\N");
-		subtitle = subtitle.replace("\n", "\\N");
-		subtitle = subtitle.replace("\r", "\\N");
+		subtitle = subtitle.replace(QStringLiteral("\r\n"), QStringLiteral("\\N"));
+		subtitle = subtitle.replace(QStringLiteral("\n"), QStringLiteral("\\N"));
+		subtitle = subtitle.replace(QStringLiteral("\r"), QStringLiteral("\\N"));
 
 		return subtitle;
 	}
@@ -102,15 +98,15 @@ protected:
 		while(data.at(end).isSpace() && end >= begin)
 			end--;
 
-		return data.mid(begin, end - begin + 1) + "\n\n";
+		return data.mid(begin, end - begin + 1) + QStringLiteral("\n\n");
 	}
 
 	virtual QString dumpSubtitles(const Subtitle &subtitle, bool primary) const
 	{
 		FormatData *formatData = this->formatData(subtitle);
 
-		QString ret = normalizeBlock(formatData ? formatData->value("ScriptInfo") : m_defaultScriptInfo)
-				+ normalizeBlock(formatData ? formatData->value("Styles") : m_defaultStyles)
+		QString ret = normalizeBlock(formatData ? formatData->value(QStringLiteral("ScriptInfo")) : m_defaultScriptInfo)
+				+ normalizeBlock(formatData ? formatData->value(QStringLiteral("Styles")) : m_defaultStyles)
 				+ normalizeBlock(m_events);
 
 		for(SubtitleIterator it(subtitle); it.current(); ++it) {
@@ -133,7 +129,7 @@ protected:
 
 			formatData = this->formatData(line);
 
-			ret += QString(formatData ? formatData->value("Dialogue") : m_dialogueBuilder)
+			ret += QString(formatData ? formatData->value(QStringLiteral("Dialogue")) : m_dialogueBuilder)
 					.arg(showTimeArg)
 					.arg(hideTimeArg)
 					.arg(fromSString(primary ? line->primaryText() : line->secondaryText()));
@@ -142,8 +138,8 @@ protected:
 	}
 
 	SubStationAlphaOutputFormat(
-			const QString &name = "SubStation Alpha",
-			const QStringList &extensions = QStringList("ssa"),
+			const QString &name = QStringLiteral("SubStation Alpha"),
+			const QStringList &extensions = QStringList(QStringLiteral("ssa")),
 			const QString &scriptInfo = s_defaultScriptInfo,
 			const QString &styles = s_defaultStyles,
 			const QString &events = s_events,

--- a/src/formats/subviewer1/subviewer1inputformat.h
+++ b/src/formats/subviewer1/subviewer1inputformat.h
@@ -20,10 +20,6 @@
  *   Boston, MA 02110-1301, USA.                                           *
  ***************************************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "../inputformat.h"
 
 #include <QRegExp>
@@ -47,7 +43,7 @@ protected:
 
 			Time showTime(m_regExp.cap(1).toInt(), m_regExp.cap(2).toInt(), m_regExp.cap(3).toInt(), 0);
 
-			QString text(m_regExp.cap(4).replace("|", "\n").trimmed());
+			QString text(m_regExp.cap(4).replace('|', '\n').trimmed());
 
 			// search hideTime
 			if(m_regExp.indexIn(data, offset) == -1)
@@ -60,14 +56,14 @@ protected:
 			offset += m_regExp.matchedLength();
 
 			readLines++;
-		} while(m_regExp.indexIn(data, offset) != -1);          // search next line's showTime
+		} while(m_regExp.indexIn(data, offset) != -1); // search next line's showTime
 
 		return readLines > 0;
 	}
 
 	SubViewer1InputFormat() :
-		InputFormat("SubViewer 1.0", QStringList("sub")),
-		m_regExp("\\[([0-2][0-9]):([0-5][0-9]):([0-5][0-9])\\]\n([^\n]*)\n")
+		InputFormat(QStringLiteral("SubViewer 1.0"), QStringList(QStringLiteral("sub"))),
+		m_regExp(QStringLiteral("\\[([0-2][0-9]):([0-5][0-9]):([0-5][0-9])\\]\n([^\n]*)\n"))
 	{}
 
 	mutable QRegExp m_regExp;

--- a/src/formats/subviewer1/subviewer1outputformat.h
+++ b/src/formats/subviewer1/subviewer1outputformat.h
@@ -20,10 +20,6 @@
  *   Boston, MA 02110-1301, USA.                                           *
  ***************************************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "../outputformat.h"
 #include "../../core/subtitleiterator.h"
 
@@ -35,9 +31,7 @@ class SubViewer1OutputFormat : public OutputFormat
 protected:
 	virtual QString dumpSubtitles(const Subtitle &subtitle, bool primary) const
 	{
-		QString ret;
-
-		ret += "[TITLE]\n\n[AUTHOR]\n\n[SOURCE]\n\n[PRG]\n\n[FILEPATH]\n\n[DELAY]\n0\n[CD TRACK]\n0\n[BEGIN]\n" "******** START SCRIPT ********\n";
+		QString ret(QStringLiteral("[TITLE]\n\n[AUTHOR]\n\n[SOURCE]\n\n[PRG]\n\n[FILEPATH]\n\n[DELAY]\n0\n[CD TRACK]\n0\n[BEGIN]\n" "******** START SCRIPT ********\n"));
 
 		for(SubtitleIterator it(subtitle); it.current(); ++it) {
 			const SubtitleLine *line = it.current();
@@ -57,7 +51,7 @@ protected:
 	}
 
 	SubViewer1OutputFormat() :
-		OutputFormat("SubViewer 1.0", QStringList("sub"))
+		OutputFormat(QStringLiteral("SubViewer 1.0"), QStringList(QStringLiteral("sub")))
 	{}
 
 	mutable QString m_builder;

--- a/src/formats/subviewer2/subviewer2inputformat.h
+++ b/src/formats/subviewer2/subviewer2inputformat.h
@@ -20,10 +20,6 @@
  *   Boston, MA 02110-1301, USA.                                           *
  ***************************************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "../inputformat.h"
 
 #include <QRegExp>
@@ -44,7 +40,7 @@ protected:
 			Time hideTime(m_lineRegExp.cap(5).toInt(), m_lineRegExp.cap(6).toInt(), m_lineRegExp.cap(7).toInt(), m_lineRegExp.cap(8).toInt() * 10);
 
 			int styleFlags = 0;
-			QString text = m_lineRegExp.cap(9).replace("[br]", "\n").trimmed();
+			QString text = m_lineRegExp.cap(9).replace(QLatin1String("[br]"), QLatin1String("\n")).trimmed();
 			if(m_styleRegExp.indexIn(text) != -1) {
 				QString styleText(m_styleRegExp.cap(1));
 				if(styleText.contains('b', Qt::CaseInsensitive))
@@ -65,9 +61,9 @@ protected:
 	}
 
 	SubViewer2InputFormat() :
-		InputFormat("SubViewer 2.0", QStringList("sub")),
-		m_lineRegExp("([0-2][0-9]):([0-5][0-9]):([0-5][0-9])\\.([0-9][0-9])," "([0-2][0-9]):([0-5][0-9]):([0-5][0-9])\\.([0-9][0-9])\n" "([^\n]*)\n\n", Qt::CaseInsensitive),
-		m_styleRegExp("(\\{y:[ubi]+\\})", Qt::CaseInsensitive)
+		InputFormat(QStringLiteral("SubViewer 2.0"), QStringList(QStringLiteral("sub"))),
+		m_lineRegExp(QStringLiteral("([0-2][0-9]):([0-5][0-9]):([0-5][0-9])\\.([0-9][0-9])," "([0-2][0-9]):([0-5][0-9]):([0-5][0-9])\\.([0-9][0-9])\n" "([^\n]*)\n\n"), Qt::CaseInsensitive),
+		m_styleRegExp(QStringLiteral("(\\{y:[ubi]+\\})"), Qt::CaseInsensitive)
 	{}
 
 	mutable QRegExp m_lineRegExp;

--- a/src/formats/subviewer2/subviewer2outputformat.h
+++ b/src/formats/subviewer2/subviewer2outputformat.h
@@ -20,10 +20,6 @@
  *   Boston, MA 02110-1301, USA.                                           *
  ***************************************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "../outputformat.h"
 #include "../../core/subtitleiterator.h"
 
@@ -35,36 +31,35 @@ class SubViewer2OutputFormat : public OutputFormat
 protected:
 	virtual QString dumpSubtitles(const Subtitle &subtitle, bool primary) const
 	{
-		QString ret("[INFORMATION]\n[TITLE]\n[AUTHOR]\n[SOURCE]\n[PRG]\n[FILEPATH]\n[DELAY]0\n[CD TRACK]0\n" "[COMMENT]\n[END INFORMATION]\n[SUBTITLE]\n[COLF]&HFFFFFF,[STYLE]bd,[SIZE]24,[FONT]Tahoma\n");
+		QString ret(QStringLiteral("[INFORMATION]\n[TITLE]\n[AUTHOR]\n[SOURCE]\n[PRG]\n[FILEPATH]\n[DELAY]0\n[CD TRACK]0\n" "[COMMENT]\n[END INFORMATION]\n[SUBTITLE]\n[COLF]&HFFFFFF,[STYLE]bd,[SIZE]24,[FONT]Tahoma\n"));
 
 		for(SubtitleIterator it(subtitle); it.current(); ++it) {
 			const SubtitleLine *line = it.current();
 
 			Time showTime = line->showTime();
 			Time hideTime = line->hideTime();
-			ret += m_builder.sprintf("%02d:%02d:%02d.%02d,%02d:%02d:%02d.%02d\n", showTime.hours(), showTime.minutes(), showTime.seconds(), (int)((showTime.mseconds() + 5) / 10), hideTime.hours(), hideTime.minutes(), hideTime.seconds(), (int)((hideTime.mseconds() + 5) / 10)
-									 );
+			ret += m_builder.sprintf("%02d:%02d:%02d.%02d,%02d:%02d:%02d.%02d\n", showTime.hours(), showTime.minutes(), showTime.seconds(), (showTime.mseconds() + 5) / 10, hideTime.hours(), hideTime.minutes(), hideTime.seconds(), (hideTime.mseconds() + 5) / 10);
 
 			const SString &text = primary ? line->primaryText() : line->secondaryText();
 			ret += m_stylesMap[text.cummulativeStyleFlags()];
 			ret += text.string().replace("\n", "[br]");
 
-			ret += "\n\n";
+			ret += QStringLiteral("\n\n");
 		}
 		return ret;
 	}
 
 	SubViewer2OutputFormat() :
-		OutputFormat("SubViewer 2.0", QStringList("sub")),
+		OutputFormat(QStringLiteral("SubViewer 2.0"), QStringList(QStringLiteral("sub"))),
 		m_stylesMap()
 	{
-		m_stylesMap[SString::Bold] = "{Y:b}";
-		m_stylesMap[SString::Italic] = "{Y:i}";
-		m_stylesMap[SString::Underline] = "{Y:u}";
-		m_stylesMap[SString::Bold | SString::Italic] = "{Y:bi}";
-		m_stylesMap[SString::Bold | SString::Underline] = "{Y:ub}";
-		m_stylesMap[SString::Italic | SString::Underline] = "{Y:ui}";
-		m_stylesMap[SString::Bold | SString::Italic | SString::Underline] = "{Y:ubi}";
+		m_stylesMap[SString::Bold] = QStringLiteral("{Y:b}");
+		m_stylesMap[SString::Italic] = QStringLiteral("{Y:i}");
+		m_stylesMap[SString::Underline] = QStringLiteral("{Y:u}");
+		m_stylesMap[SString::Bold | SString::Italic] = QStringLiteral("{Y:bi}");
+		m_stylesMap[SString::Bold | SString::Underline] = QStringLiteral("{Y:ub}");
+		m_stylesMap[SString::Italic | SString::Underline] = QStringLiteral("{Y:ui}");
+		m_stylesMap[SString::Bold | SString::Italic | SString::Underline] = QStringLiteral("{Y:ubi}");
 	}
 
 	mutable QString m_builder;

--- a/src/formats/textdemux/textdemux.h
+++ b/src/formats/textdemux/textdemux.h
@@ -20,7 +20,6 @@
  * Boston, MA 02110-1301, USA.
  */
 
-
 #include <QObject>
 
 QT_FORWARD_DECLARE_CLASS(QWidget)

--- a/src/formats/tmplayer/tmplayerinputformat.h
+++ b/src/formats/tmplayer/tmplayerinputformat.h
@@ -20,10 +20,6 @@
  *   Boston, MA 02110-1301, USA.                                           *
  ***************************************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "../inputformat.h"
 
 #include <QRegExp>
@@ -44,12 +40,12 @@ protected:
 			return false;
 
 		Time previousShowTime(m_regExp.cap(1).toInt(), m_regExp.cap(2).toInt(), m_regExp.cap(3).toInt(), 0);
-		QString previousText(m_regExp.cap(4).replace("|", "\n").trimmed());
+		QString previousText(m_regExp.cap(4).replace('|', '\n').trimmed());
 
 		int offset = m_regExp.matchedLength();
 		for(; m_regExp.indexIn(data, offset) != -1; offset += m_regExp.matchedLength()) {
 			Time showTime(m_regExp.cap(1).toInt(), m_regExp.cap(2).toInt(), m_regExp.cap(3).toInt(), 0);
-			QString text(m_regExp.cap(4).replace("|", "\n").trimmed());
+			QString text(m_regExp.cap(4).replace('|', '\n').trimmed());
 
 			// To compensate for the format deficiencies, Subtitle Composer writes empty lines
 			// indicating that way the line hide time. We do the same.

--- a/src/formats/tmplayer/tmplayeroutputformat.h
+++ b/src/formats/tmplayer/tmplayeroutputformat.h
@@ -20,10 +20,6 @@
  *   Boston, MA 02110-1301, USA.                                           *
  ***************************************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "../outputformat.h"
 #include "../../core/subtitleiterator.h"
 
@@ -42,8 +38,7 @@ protected:
 			const SubtitleLine *line = it.current();
 
 			Time showTime = line->showTime();
-			ret += builder.sprintf(m_timeFormat, showTime.hours(), showTime.minutes(), showTime.seconds()
-								   );
+			ret += builder.sprintf(m_timeFormat, showTime.hours(), showTime.minutes(), showTime.seconds());
 
 			const SString &text = primary ? line->primaryText() : line->secondaryText();
 			ret += text.string().replace('\n', '|');
@@ -52,10 +47,9 @@ protected:
 			// We behave like Subtitle Workshop here: to compensate for the lack of hide time
 			// indication provisions in the format we add an empty line with the hide time.
 			Time hideTime = line->hideTime();
-			ret += builder.sprintf(m_timeFormat, hideTime.hours(), hideTime.minutes(), hideTime.seconds()
-								   );
+			ret += builder.sprintf(m_timeFormat, hideTime.hours(), hideTime.minutes(), hideTime.seconds());
 
-			ret += "\n";
+			ret += '\n';
 		}
 		return ret;
 	}

--- a/src/formats/youtubecaptions/youtubecaptionsinputformat.h
+++ b/src/formats/youtubecaptions/youtubecaptionsinputformat.h
@@ -20,10 +20,6 @@
  *   Boston, MA 02110-1301, USA.                                           *
  ***************************************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "../inputformat.h"
 
 #include <QRegExp>
@@ -49,11 +45,11 @@ protected:
 
 			offset += m_regExp.matchedLength();
 
-			QString text(data.mid(offset, (unsigned)m_regExp.indexIn(data, offset) - offset));
+			QString text(data.mid(offset, m_regExp.indexIn(data, offset) - offset));
 
 			offset += text.length();
 
-			// TODO does the format actually supports styled text?
+			// TODO does the format actually support styled text?
 			// if so, does it use standard HTML style tags?
 			SString stext;
 			stext.setRichString(text.trimmed());
@@ -67,8 +63,8 @@ protected:
 	}
 
 	YouTubeCaptionsInputFormat() :
-		InputFormat("YouTube Captions", QStringList("sbv")),
-		m_regExp("[\\d]+\n([0-2][0-9]):([0-5][0-9]):([0-5][0-9])[,\\.]([0-9][0-9][0-9]),([0-2][0-9]):([0-5][0-9]):([0-5][0-9])[,\\.]([0-9][0-9][0-9])\n")
+		InputFormat(QStringLiteral("YouTube Captions"), QStringList(QStringLiteral("sbv"))),
+		m_regExp(QStringLiteral("[\\d]+\n([0-2][0-9]):([0-5][0-9]):([0-5][0-9])[,\\.]([0-9][0-9][0-9]),([0-2][0-9]):([0-5][0-9]):([0-5][0-9])[,\\.]([0-9][0-9][0-9])\n"))
 	{}
 
 	mutable QRegExp m_regExp;

--- a/src/formats/youtubecaptions/youtubecaptionsoutputformat.h
+++ b/src/formats/youtubecaptions/youtubecaptionsoutputformat.h
@@ -20,10 +20,6 @@
  *   Boston, MA 02110-1301, USA.                                           *
  ***************************************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "../outputformat.h"
 #include "../../core/subtitleiterator.h"
 


### PR DESCRIPTION
I altered the mentioned Regex to enable the parser to read ASS files demuxed with ffmpeg.

Additionally, I changed lots of minor things in src/formats/* (mostly string literals, removal of unneeded headers and casts).