### PR TITLE
Fix waveform "Insert Line", add extra option, and use MMB to scroll waveform

### DIFF
--- a/src/configs/generalconfigwidget.ui
+++ b/src/configs/generalconfigwidget.ui
@@ -44,14 +44,14 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="QCheckBox" name="kcfg_UnpauseOnDoubleClick">
         <property name="text">
          <string>Resume playback after line double click</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="5" column="1">
        <widget class="QCheckBox" name="kcfg_AutomaticVideoLoad">
         <property name="text">
          <string>Automatically load video file when opening a subtitle</string>
@@ -67,6 +67,23 @@
       </item>
       <item row="2" column="1">
        <widget class="QSpinBox" name="kcfg_JumpLineOffset">
+        <property name="suffix">
+         <string> msec</string>
+        </property>
+        <property name="maximum">
+         <number>10000</number>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" alignment="Qt::AlignRight">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Padding between new lines:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QSpinBox" name="kcfg_NewLinePadding">
         <property name="suffix">
          <string> msec</string>
         </property>

--- a/src/configs/generalconfigwidget.ui
+++ b/src/configs/generalconfigwidget.ui
@@ -76,14 +76,31 @@
        </widget>
       </item>
       <item row="3" column="0" alignment="Qt::AlignRight">
-       <widget class="QLabel" name="label_2">
+       <widget class="QLabel" name="label_LineMargin">
         <property name="text">
-         <string>Padding between new lines:</string>
+         <string>Default duration between subtitle lines:</string>
         </property>
        </widget>
       </item>
       <item row="3" column="1">
-       <widget class="QSpinBox" name="kcfg_NewLinePadding">
+       <widget class="QSpinBox" name="kcfg_LineMargin">
+        <property name="suffix">
+         <string> msec</string>
+        </property>
+        <property name="maximum">
+         <number>10000</number>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" alignment="Qt::AlignRight">
+       <widget class="QLabel" name="label_LineDuration">
+        <property name="text">
+         <string>Default subtitle line duration:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QSpinBox" name="kcfg_LineDuration">
         <property name="suffix">
          <string> msec</string>
         </property>

--- a/src/core/subtitle.cpp
+++ b/src/core/subtitle.cpp
@@ -416,26 +416,28 @@ Subtitle::insertNewLine(int index, bool timeAfter, TextTarget target)
 	SubtitleLine *newLine = new SubtitleLine();
 	int newLineIndex = (target == Secondary) ? m_lines.count() : index;
 
-	double newLinePadding = (double)SCConfig::newLinePadding();
+	double lineMargin = (double)SCConfig::lineMargin();
+	double lineDuration = (double)SCConfig::lineDuration();
+	double lineDurationMargin = lineDuration + lineMargin;
 
 	if(timeAfter) {
 		if(newLineIndex) {              // there is a previous line
 			SubtitleLine *prevLine = m_lines.value(newLineIndex - 1);
-			newLine->setTimes(prevLine->hideTime() + newLinePadding, prevLine->hideTime() + 1000.);
+			newLine->setTimes(prevLine->hideTime() + lineMargin, prevLine->hideTime() + lineDurationMargin);
 		} else if(newLineIndex < m_lines.count()) {     // there is a next line
 			SubtitleLine *nextLine = m_lines.value(newLineIndex);
-			newLine->setTimes(nextLine->showTime() - 1100., nextLine->showTime() - newLinePadding);
+			newLine->setTimes(nextLine->showTime() - lineDurationMargin, nextLine->showTime() - lineMargin);
 		} else
-			newLine->setHideTime(1000.);
+			newLine->setHideTime(lineDuration);
 	} else {                                        // ! timeAfter
 		if(newLineIndex < m_lines.count()) {    // there is a next line
 			SubtitleLine *nextLine = m_lines.at(newLineIndex);
-			newLine->setTimes(nextLine->showTime() - 1100., nextLine->showTime() - newLinePadding);
+			newLine->setTimes(nextLine->showTime() - lineDurationMargin, nextLine->showTime() - lineMargin);
 		} else if(newLineIndex) {       // there is a previous line
 			SubtitleLine *prevLine = m_lines.at(newLineIndex - 1);
-			newLine->setTimes(prevLine->hideTime() + newLinePadding, prevLine->hideTime() + 1000.);
+			newLine->setTimes(prevLine->hideTime() + lineMargin, prevLine->hideTime() + lineDurationMargin);
 		} else
-			newLine->setHideTime(1000.);
+			newLine->setHideTime(lineDuration);
 	}
 
 	if(target == Both || index == m_lines.count()) {

--- a/src/core/subtitle.cpp
+++ b/src/core/subtitle.cpp
@@ -383,6 +383,43 @@ Subtitle::removeAllAnchors()
 		emit lineAnchorChanged(line, false);
 }
 
+int
+Subtitle::indexForTime(Time time)
+{
+	int index = 0;
+	foreach(SubtitleLine *sub, allLines()) {
+		if(sub->showTime() > time) {
+			index = sub->index();
+			break;
+		} else {
+			index++;
+		}
+	}
+
+	return index;
+}
+
+void
+Subtitle::reIndex(SubtitleLine* line)
+{
+	int oldIndex = line->index();
+	int newIndex = indexForTime(line->showTime()) - 1;
+	if (newIndex < 0)
+		newIndex = 0;
+
+	if (oldIndex == newIndex)
+		return;
+
+	m_lines.removeOne(line);
+	m_lines.insert(newIndex, line);
+
+	int i = 0;
+	foreach(SubtitleLine* sub, allLines()) {
+		sub->m_cachedIndex = i;
+		i++;
+	}
+}
+
 void
 Subtitle::insertLine(SubtitleLine *line, int index)
 {

--- a/src/core/subtitle.cpp
+++ b/src/core/subtitle.cpp
@@ -23,6 +23,7 @@
 #include "subtitleiterator.h"
 #include "subtitleactions.h"
 #include "compositeaction.h"
+#include "scconfig.h"
 
 #include <KLocalizedString>
 
@@ -415,22 +416,24 @@ Subtitle::insertNewLine(int index, bool timeAfter, TextTarget target)
 	SubtitleLine *newLine = new SubtitleLine();
 	int newLineIndex = (target == Secondary) ? m_lines.count() : index;
 
+	double newLinePadding = (double)SCConfig::newLinePadding();
+
 	if(timeAfter) {
 		if(newLineIndex) {              // there is a previous line
 			SubtitleLine *prevLine = m_lines.value(newLineIndex - 1);
-			newLine->setTimes(prevLine->hideTime() + 100., prevLine->hideTime() + 1000.);
+			newLine->setTimes(prevLine->hideTime() + newLinePadding, prevLine->hideTime() + 1000.);
 		} else if(newLineIndex < m_lines.count()) {     // there is a next line
 			SubtitleLine *nextLine = m_lines.value(newLineIndex);
-			newLine->setTimes(nextLine->showTime() - 1100., nextLine->showTime() - 100.);
+			newLine->setTimes(nextLine->showTime() - 1100., nextLine->showTime() - newLinePadding);
 		} else
 			newLine->setHideTime(1000.);
 	} else {                                        // ! timeAfter
 		if(newLineIndex < m_lines.count()) {    // there is a next line
 			SubtitleLine *nextLine = m_lines.at(newLineIndex);
-			newLine->setTimes(nextLine->showTime() - 1100., nextLine->showTime() - 100.);
+			newLine->setTimes(nextLine->showTime() - 1100., nextLine->showTime() - newLinePadding);
 		} else if(newLineIndex) {       // there is a previous line
 			SubtitleLine *prevLine = m_lines.at(newLineIndex - 1);
-			newLine->setTimes(prevLine->hideTime() + 100., prevLine->hideTime() + 1000.);
+			newLine->setTimes(prevLine->hideTime() + newLinePadding, prevLine->hideTime() + 1000.);
 		} else
 			newLine->setHideTime(1000.);
 	}
@@ -1562,5 +1565,3 @@ SubtitleCompositeActionExecutor::~SubtitleCompositeActionExecutor()
 {
 	m_subtitle.endCompositeAction();
 }
-
-

--- a/src/core/subtitle.h
+++ b/src/core/subtitle.h
@@ -121,6 +121,9 @@ public:
 	void toggleLineAnchor(const SubtitleLine *line);
 	void removeAllAnchors();
 
+	int indexForTime(Time time);
+	void reIndex(SubtitleLine* line);
+
 	void insertLine(SubtitleLine *line, int index = -1);
 	void insertLines(const QList<SubtitleLine *> &lines, int index = -1);
 	SubtitleLine * insertNewLine(int index, bool timeAfter, TextTarget target);

--- a/src/core/subtitlelineactions.cpp
+++ b/src/core/subtitlelineactions.cpp
@@ -355,6 +355,8 @@ SetLineTimesAction::internalRedo()
 		m_line.m_hideTime = m_hideTime;
 		m_hideTime = aux;
 	}
+
+	m_line.m_subtitle->reIndex(&m_line);
 }
 
 void

--- a/src/scconfig.kcfg
+++ b/src/scconfig.kcfg
@@ -35,6 +35,11 @@
 			<label>Grabbed Position Compensation</label>
 			<default>250</default>
 		</entry>
+
+		<entry name="NewLinePadding" type="Int">
+			<label>Padding between new lines</label>
+			<default>100</default>
+		</entry>
 	</group>
 
 	<group name="Error Check">

--- a/src/scconfig.kcfg
+++ b/src/scconfig.kcfg
@@ -36,9 +36,14 @@
 			<default>250</default>
 		</entry>
 
-		<entry name="NewLinePadding" type="Int">
-			<label>Padding between new lines</label>
+		<entry name="LineMargin" type="Int">
+			<label>Default duration between subtitle lines</label>
 			<default>100</default>
+		</entry>
+
+		<entry name="LineDuration" type="Int">
+			<label>Default subtitle line duration</label>
+			<default>1000</default>
 		</entry>
 	</group>
 

--- a/src/waveformwidget.cpp
+++ b/src/waveformwidget.cpp
@@ -1091,8 +1091,7 @@ WaveformWidget::showContextMenu(QMouseEvent *event)
 
 				int insertIndex = 0;
 				foreach(SubtitleLine *sub, m_subtitle->allLines()) {
-					if(sub->showTime() <= timeShow)
-						insertIndex++;
+					insertIndex++;
 
 					if(sub->showTime() > timeShow) {
 						insertIndex = sub->index();

--- a/src/waveformwidget.cpp
+++ b/src/waveformwidget.cpp
@@ -1089,15 +1089,7 @@ WaveformWidget::showContextMenu(QMouseEvent *event)
 				const Time timeShow = rightMouseSoonerTime();
 				const Time timeHide = rightMouseLaterTime();
 
-				int insertIndex = 0;
-				foreach(SubtitleLine *sub, m_subtitle->allLines()) {
-					insertIndex++;
-
-					if(sub->showTime() > timeShow) {
-						insertIndex = sub->index();
-						break;
-					}
-				}
+				int insertIndex = m_subtitle->indexForTime(timeShow);
 
 				SubtitleLine *newLine = new SubtitleLine(SString(), timeShow,
 					timeHide.toMillis() - timeShow.toMillis() > SCConfig::minDuration() ? timeHide : timeShow + SCConfig::minDuration());

--- a/src/waveformwidget.cpp
+++ b/src/waveformwidget.cpp
@@ -792,6 +792,11 @@ WaveformWidget::eventFilter(QObject *obj, QEvent *event)
 			scrollToTime(m_pointerTime, false);
 		}
 
+		if (m_MMBDown) {
+			emit doubleClick(timeAt(y));
+			return true;
+		}
+
 		if(m_draggedLine) {
 			m_draggedTime = m_pointerTime;
 			scrollToTime(m_pointerTime, false);
@@ -829,6 +834,12 @@ WaveformWidget::eventFilter(QObject *obj, QEvent *event)
 			return false;
 		}
 
+		if(mouse->button() == Qt::MiddleButton) {
+			emit doubleClick(timeAt(y));
+			m_MMBDown = true;
+			return true;
+		}
+
 		if(mouse->button() != Qt::LeftButton)
 			return false;
 
@@ -862,6 +873,11 @@ WaveformWidget::eventFilter(QObject *obj, QEvent *event)
 			showContextMenu(mouse);
 			m_RMBDown = false;
 			return false;
+		}
+
+		if(mouse->button() == Qt::MiddleButton) {
+			m_MMBDown = false;
+			return true;
 		}
 
 		if(mouse->button() != Qt::LeftButton)
@@ -1075,10 +1091,11 @@ WaveformWidget::showContextMenu(QMouseEvent *event)
 
 				int insertIndex = 0;
 				foreach(SubtitleLine *sub, m_subtitle->allLines()) {
+					if(sub->showTime() <= timeShow)
+						insertIndex++;
+
 					if(sub->showTime() > timeShow) {
 						insertIndex = sub->index();
-						if(sub->showTime() <= timeShow)
-							insertIndex++;
 						break;
 					}
 				}

--- a/src/waveformwidget.h
+++ b/src/waveformwidget.h
@@ -150,6 +150,8 @@ private:
 	Time m_timeRMBRelease;
 	bool m_RMBDown;
 
+	bool m_MMBDown;
+
 	QScrollBar *m_scrollBar;
 	QPropertyAnimation *m_scrollAnimation;
 	bool m_autoScroll;


### PR DESCRIPTION
This commit does the following:

 * When selecting "Insert Line" in the waveform, it'll set it at the wrong index. This fixes it
 * Middle mouse button is used to scroll the waveform, like double clicking does, except it will keep scrolling when MMB is held down. I found this to be much easier.
 * Add "New Line Padding" option, which sets the amount of padding between subtitles when selecting "Insert Before" or "Insert After". The default (100ms) is kept the same, but I added it since I personally prefer a padding of 0.

I added in these features quickly, and so I didn't think to separate them into different commits or branches, let me know if you'd rather I do this.