### PR TITLE
Add isRightToLeft function and some scripts

### DIFF
--- a/src/core/subtitleline.cpp
+++ b/src/core/subtitleline.cpp
@@ -1045,7 +1045,7 @@ SubtitleLine::check(int errorFlagsToCheck, int minDurationMsecs, int maxDuration
 }
 
 bool
-SubtitleLine::isRightToLeft()
+SubtitleLine::isRightToLeft() const
 {
 	return m_primaryText.string().isRightToLeft();
 }

--- a/src/core/subtitleline.cpp
+++ b/src/core/subtitleline.cpp
@@ -1044,6 +1044,12 @@ SubtitleLine::check(int errorFlagsToCheck, int minDurationMsecs, int maxDuration
 	return lineErrorFlags;
 }
 
+bool
+SubtitleLine::isRightToLeft()
+{
+	return m_primaryText.string().isRightToLeft();
+}
+
 void
 SubtitleLine::processAction(Action *action)
 {

--- a/src/core/subtitleline.h
+++ b/src/core/subtitleline.h
@@ -222,7 +222,7 @@ public:
 
 	int check(int errorFlagsToCheck, int minDurationMsecs, int maxDurationMsecs, int minMsecsPerChar, int maxMsecsPerChar, int maxChars, int maxLines, bool update = true);
 
-	bool isRightToLeft();
+	bool isRightToLeft() const;
 
 signals:
 	void primaryTextChanged(const SString &text);

--- a/src/core/subtitleline.h
+++ b/src/core/subtitleline.h
@@ -222,6 +222,8 @@ public:
 
 	int check(int errorFlagsToCheck, int minDurationMsecs, int maxDurationMsecs, int minMsecsPerChar, int maxMsecsPerChar, int maxChars, int maxLines, bool update = true);
 
+	bool isRightToLeft();
+
 signals:
 	void primaryTextChanged(const SString &text);
 	void secondaryTextChanged(const SString &text);

--- a/src/scripting/examples/prepare_RTL_release.py
+++ b/src/scripting/examples/prepare_RTL_release.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2018 Safa AlFulaij (safa1996alfulaij@gmail.com)
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301, USA.
+
+import ranges
+import subtitle
+
+s = subtitle.instance()
+
+# First add a “working” line
+s.insertNewLine(s.linesCount(), False)
+
+# Keep track. 2 lines = line 0 line 1
+tempLine = s.line(s.linesCount()-1)
+
+# All the lines except the last one
+for line_index in range(0, s.linesCount()-1):
+    line = s.line( line_index )
+
+    # To store the modefied sublines
+    combinedArray = []
+
+    # each line in the subtitle line
+    for eachSubLine in line.richPrimaryText().split("\n"):
+        tempLine.setRichPrimaryText(eachSubLine)
+        if tempLine.isRightToLeft():
+            combinedArray.append(u"\u202B%s"%eachSubLine.decode('utf8')) # Add RLE for RTL lines
+        else:
+            combinedArray.append(u"\u202A%s"%eachSubLine.decode('utf8')) # Add LRE for LTR lines
+
+    line.setRichPrimaryText("\n".join(combinedArray))
+
+# Delete the temp line
+s.removeLine(s.linesCount()-1)

--- a/src/scripting/examples/prepare_RTL_release.py
+++ b/src/scripting/examples/prepare_RTL_release.py
@@ -31,20 +31,20 @@ tempLine = s.line(s.linesCount()-1)
 
 # All the lines except the last one
 for line_index in range(0, s.linesCount()-1):
-    line = s.line( line_index )
+	line = s.line( line_index )
 
-    # To store the modefied sublines
-    combinedArray = []
+	# To store the modefied sublines
+	combinedArray = []
 
-    # each line in the subtitle line
-    for eachSubLine in line.richPrimaryText().split("\n"):
-        tempLine.setRichPrimaryText(eachSubLine)
-        if tempLine.isRightToLeft():
-            combinedArray.append(u"\u202B%s"%eachSubLine.decode('utf8')) # Add RLE for RTL lines
-        else:
-            combinedArray.append(u"\u202A%s"%eachSubLine.decode('utf8')) # Add LRE for LTR lines
+	# each line in the subtitle line
+	for eachSubLine in line.richPrimaryText().split("\n"):
+		tempLine.setRichPrimaryText(eachSubLine)
+		if tempLine.isRightToLeft():
+			combinedArray.append(u"\u202B%s"%eachSubLine.decode('utf8')) # Add RLE for RTL lines
+		else:
+			combinedArray.append(u"\u202A%s"%eachSubLine.decode('utf8')) # Add LRE for LTR lines
 
-    line.setRichPrimaryText("\n".join(combinedArray))
+	line.setRichPrimaryText("\n".join(combinedArray))
 
 # Delete the temp line
 s.removeLine(s.linesCount()-1)

--- a/src/scripting/examples/undo_RTL_release.py
+++ b/src/scripting/examples/undo_RTL_release.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2018 Safa AlFulaij (safa1996alfulaij@gmail.com)
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301, USA.
+
+import ranges
+import subtitle
+
+s = subtitle.instance()
+
+# All the lines
+for line_index in range(0, s.linesCount()):
+	line = s.line( line_index )
+
+	# To store the modefied sublines
+	combinedArray = []
+
+	# each line in the subtitle line
+	for eachSubLine in line.richPrimaryText().split("\n"):
+		combinedArray.append(eachSubLine.decode('utf8')[1:]) # Remove the first character (RLE/LRE)
+
+	line.setRichPrimaryText("\n".join(combinedArray))

--- a/src/scripting/scripting_subtitleline.cpp
+++ b/src/scripting/scripting_subtitleline.cpp
@@ -418,4 +418,8 @@ Scripting::SubtitleLine::check(int errorFlagsToCheck, int minDuration, int maxDu
 	return m_backend->check(errorFlagsToCheck, minDuration, maxDuration, minDurationPerChar, maxDurationPerChar, maxChars, maxLines, update);
 }
 
-
+bool
+Scripting::SubtitleLine::isRightToLeft()
+{
+	return m_backend->isRightToLeft();
+}

--- a/src/scripting/scripting_subtitleline.cpp
+++ b/src/scripting/scripting_subtitleline.cpp
@@ -419,7 +419,7 @@ Scripting::SubtitleLine::check(int errorFlagsToCheck, int minDuration, int maxDu
 }
 
 bool
-Scripting::SubtitleLine::isRightToLeft()
+Scripting::SubtitleLine::isRightToLeft() const
 {
 	return m_backend->isRightToLeft();
 }

--- a/src/scripting/scripting_subtitleline.h
+++ b/src/scripting/scripting_subtitleline.h
@@ -118,7 +118,7 @@ public slots:
 
 	int check(int errorFlagsToCheck, int minDuration, int maxDuration, int minDurationPerChar, int maxDurationPerChar, int maxChars, int maxLines, bool update = true);
 
-	bool isRightToLeft();
+	bool isRightToLeft() const;
 
 private:
 	friend class Subtitle;

--- a/src/scripting/scripting_subtitleline.h
+++ b/src/scripting/scripting_subtitleline.h
@@ -118,6 +118,8 @@ public slots:
 
 	int check(int errorFlagsToCheck, int minDuration, int maxDuration, int minDurationPerChar, int maxDurationPerChar, int maxChars, int maxLines, bool update = true);
 
+	bool isRightToLeft();
+
 private:
 	friend class Subtitle;
 


### PR DESCRIPTION
This adds a function to decide if the subtitle line is RTL or not, which makes it possible for scripts to check that and do some post-processing due to the stupidness of ASS engines (libASS and vsFilter) as well as the normal SRT format that doesn't support that, unfortunately.
I didn't check other formats supported really.